### PR TITLE
[codex] Replace event FX parser stubs with C++

### DIFF
--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -168,6 +168,7 @@ name,address,notes
 ?initFromINI@INI@@QAEXPAXPBX@Z,0x008520A0,INI::initFromINI(void*, const void*) body
 ?makeDecoratedNameKey@ModuleFactory@@KAHABVAsciiString@@H@Z,0x0004B439,ModuleFactory::makeDecoratedNameKey thunk (body 0x00126260)
 ?nameToKey@NameKeyGenerator@@QAE?AW4NameKeyType@@PBD@Z,0x0003ADD7
+?parseFXList@INI@@SAXPAV1@PAX1PBX@Z,0x00851EE0,INI::parseFXList body
 ?nstrdup@@YAPADPBD@Z,0x009E6410
 ?readUnicodeString@@YA?AVUnicodeString@@PAU_iobuf@@@Z,0x000322F4,shared replay Unicode string reader thunk
 ?set@LayoutFilename@@QAEXPBDH@Z,0x00887D20

--- a/src/game/fx_particle_system.h
+++ b/src/game/fx_particle_system.h
@@ -11,6 +11,7 @@ class AssetList;
 class INI {
 public:
     void initFromINI(void *data, const void *parseTable);
+    static void parseFXList(INI *ini, void *data, void *store, const void *userData);
 };
 class File;
 class FXList;

--- a/src/game/fx_particle_system_bulk.cpp
+++ b/src/game/fx_particle_system_bulk.cpp
@@ -26454,43 +26454,15 @@ void TerrainCollisionModuleTemplate::parse(INI *ini)
 }
 
 // ?parseEventFXListName@LifeEventModuleTemplate@FXParticleSystem@@SAXPAVINI@@PAX1PBX@Z
-__declspec(naked) void LifeEventModuleTemplate::parseEventFXListName(INI *ini, void *data, void *store, const void *userData)
+void LifeEventModuleTemplate::parseEventFXListName(INI *ini, void *data, void *store, const void *userData)
 {
-    __asm {
-        __emit 0xc7
-        __emit 0x44
-        __emit 0x24
-        __emit 0x10
-        __emit 0x00
-        __emit 0x00
-        __emit 0x00
-        __emit 0x00
-        __emit 0xe9
-        __emit 0xe3
-        __emit 0x5b
-        __emit 0x25
-        __emit 0x00
-    }
+    INI::parseFXList(ini, data, store, 0);
 }
 
 // ?parseEventFXListName@TerrainCollisionModuleTemplate@FXParticleSystem@@SAXPAVINI@@PAX1PBX@Z
-__declspec(naked) void TerrainCollisionModuleTemplate::parseEventFXListName(INI *ini, void *data, void *store, const void *userData)
+void TerrainCollisionModuleTemplate::parseEventFXListName(INI *ini, void *data, void *store, const void *userData)
 {
-    __asm {
-        __emit 0xc7
-        __emit 0x44
-        __emit 0x24
-        __emit 0x10
-        __emit 0x00
-        __emit 0x00
-        __emit 0x00
-        __emit 0x00
-        __emit 0xe9
-        __emit 0xf3
-        __emit 0x4f
-        __emit 0x25
-        __emit 0x00
-    }
+    INI::parseFXList(ini, data, store, 0);
 }
 
 // ?tintAllColors@DefaultColorModuleInfo@FXParticleSystem@@QAEXH@Z


### PR DESCRIPTION
## Summary

This replaces two `parseEventFXListName` raw byte stubs with readable C++ wrappers that forward to `INI::parseFXList`.

It also adds the `INI::parseFXList` declaration and symbol address needed by the matching/build tooling.

## Validation

- Full verification passed: `2088/2088` functions matched across `109` source files.
- No-op patched executable passed.
- Commit hook verification passed for the touched source file: `282/282` functions matched.
