### PR TITLE
[codex] Replace texture filename setter stub with C++

### DIFF
--- a/src/game/fx_particle_system.cpp
+++ b/src/game/fx_particle_system.cpp
@@ -1,6 +1,8 @@
 #define FX_PARTICLE_SYSTEM_CPP
 #include "fx_particle_system.h"
 
+#include "string_base.h"
+
 #include "../math/region.h"
 
 namespace FXParticleSystem {
@@ -881,18 +883,10 @@ __declspec(naked) AsciiString ParticleSystemTemplate::getTextureFilename() const
     }
 }
 
-__declspec(naked) void ParticleSystemTemplate::setTextureFilename(AsciiString &filename)
+void ParticleSystemTemplate::setTextureFilename(AsciiString &filename)
 {
-    __asm {
-        __emit 0x83
-        __emit 0xc1
-        __emit 0x10
-        __emit 0xe9
-        __emit 0x38
-        __emit 0xb1
-        __emit 0x82
-        __emit 0x00
-    }
+    reinterpret_cast<StringBase<char> *>(reinterpret_cast<char *>(this) + 0x10)->set(
+        *reinterpret_cast<const StringBase<char> *>(&filename));
 }
 
 __declspec(naked) void ParticleSystemTemplate::setSlaveSystemName(const AsciiString &name)


### PR DESCRIPTION
## Summary

This replaces the raw byte stub for `ParticleSystemTemplate::setTextureFilename` with a small C++ wrapper.

The implementation keeps the original layout behavior by assigning through the `StringBase<char>` stored at the texture filename offset, matching the original tail call while making the code easier to read.

## Validation

- Targeted verification passed for `ParticleSystemTemplate::setTextureFilename`.
- Full verification passed: `2103/2103` functions matched across `113` source files.
- No-op patched executable passed.
