### PR TITLE
[codex] Replace small native stubs with C++

### DIFF
--- a/Code/GameEngine/Source/GameClient/System/FXParticleSystem/fx_particle_system.cpp
+++ b/Code/GameEngine/Source/GameClient/System/FXParticleSystem/fx_particle_system.cpp
@@ -890,40 +890,11 @@ void ParticleSystemTemplate::setTextureFilename(AsciiString &filename)
         *reinterpret_cast<const StringBase<char> *>(&filename));
 }
 
-__declspec(naked) void ParticleSystemTemplate::setSlaveSystemName(const AsciiString &name)
+void ParticleSystemTemplate::setSlaveSystemName(const AsciiString &name)
 {
-    __asm {
-        __emit 0x8b
-        __emit 0x44
-        __emit 0x24
-        __emit 0x04
-        __emit 0x56
-        __emit 0x8b
-        __emit 0xf1
-        __emit 0x50
-        __emit 0x8d
-        __emit 0x4e
-        __emit 0x68
-        __emit 0xe8
-        __emit 0xf0
-        __emit 0x95
-        __emit 0x2c
-        __emit 0x00
-        __emit 0xc7
-        __emit 0x86
-        __emit 0x9c
-        __emit 0x00
-        __emit 0x00
-        __emit 0x00
-        __emit 0x00
-        __emit 0x00
-        __emit 0x00
-        __emit 0x00
-        __emit 0x5e
-        __emit 0xc2
-        __emit 0x04
-        __emit 0x00
-    }
+    reinterpret_cast<StringBase<char> *>(reinterpret_cast<char *>(this) + 0x68)->set(
+        *reinterpret_cast<const StringBase<char> *>(&name));
+    *reinterpret_cast<unsigned int *>(reinterpret_cast<char *>(this) + 0x9c) = 0;
 }
 
 ParticleType ParticleSystemTemplate::getParticleType() const

--- a/Code/GameEngine/Source/GameNetwork/native_netcommandmsg.cpp
+++ b/Code/GameEngine/Source/GameNetwork/native_netcommandmsg.cpp
@@ -10,45 +10,31 @@ public:
 };
 
 // BFME command type 7 is NETCOMMANDTYPE_REQUESTPLAYERLEAVE, not ZH run-ahead.
-__declspec(naked) void *BFMENetRequestPlayerLeaveCommandMsg::construct()
+void *BFMENetRequestPlayerLeaveCommandMsg::construct()
 {
-	__asm {
-		mov eax, ecx
-		xor ecx, ecx
-		or edx, 0FFFFFFFFh
-		mov dword ptr [eax+08h], edx
-		mov word ptr [eax+10h], cx
-		mov dword ptr [eax+0Ch], ecx
-		mov dword ptr [eax+04h], ecx
-		mov dword ptr [eax+18h], 1
-		mov dword ptr [eax], 0111A5A0h
-		mov dword ptr [eax+14h], 7
-		mov dword ptr [eax+1Ch], edx
-		ret
-	}
+	char *base = reinterpret_cast<char *>(this);
+	*reinterpret_cast<unsigned int *>(base + 0x08) = 0xffffffff;
+	*reinterpret_cast<unsigned short *>(base + 0x10) = 0;
+	*reinterpret_cast<unsigned int *>(base + 0x0c) = 0;
+	*reinterpret_cast<unsigned int *>(base + 0x04) = 0;
+	*reinterpret_cast<unsigned int *>(base + 0x18) = 1;
+	*reinterpret_cast<unsigned int *>(base) = 0x0111a5a0;
+	*reinterpret_cast<unsigned int *>(base + 0x14) = 7;
+	*reinterpret_cast<unsigned int *>(base + 0x1c) = 0xffffffff;
+	return this;
 }
 
-__declspec(naked) void BFMENetRequestPlayerLeaveCommandMsg::destruct()
+void BFMENetRequestPlayerLeaveCommandMsg::destruct()
 {
-	__asm {
-		mov dword ptr [ecx], 0111A20Ch
-		ret
-	}
+	*reinterpret_cast<unsigned int *>(this) = 0x0111a20c;
 }
 
-__declspec(naked) void BFMENetRequestPlayerLeaveCommandMsg::setRequestedPlayerID(int playerID)
+void BFMENetRequestPlayerLeaveCommandMsg::setRequestedPlayerID(int playerID)
 {
-	__asm {
-		mov eax, dword ptr [esp+04h]
-		mov dword ptr [ecx+1Ch], eax
-		ret 4
-	}
+	*reinterpret_cast<int *>(reinterpret_cast<char *>(this) + 0x1c) = playerID;
 }
 
-__declspec(naked) int BFMENetRequestPlayerLeaveCommandMsg::getRequestedPlayerID()
+int BFMENetRequestPlayerLeaveCommandMsg::getRequestedPlayerID()
 {
-	__asm {
-		mov eax, dword ptr [ecx+1Ch]
-		ret
-	}
+	return *reinterpret_cast<int *>(reinterpret_cast<char *>(this) + 0x1c);
 }

--- a/Code/GameEngine/Source/GameNetwork/native_network.cpp
+++ b/Code/GameEngine/Source/GameNetwork/native_network.cpp
@@ -243,46 +243,16 @@ doneBackendDeleting:
 	}
 }
 
-__declspec(naked) void BFMENetworkBackend::openLiveHandle()
+void BFMENetworkBackend::openLiveHandle()
 {
-	__asm {
-		push esi
-		mov esi, ecx
-		lea eax, [esi+44h]
-		push eax
-		push 4
-		push esi
-		push 00ddb630h
-		push 0
-		push 0
-		__emit 0xff
-		__emit 0x15
-		__emit 0x98
-		__emit 0x92
-		__emit 0x35
-		__emit 0x01
-		mov ecx, [esi+4ch]
-		add esp, 18h
-		push ecx
-		push eax
-		mov [esi+48h], eax
-		__emit 0xff
-		__emit 0x15
-		__emit 0x20
-		__emit 0x8f
-		__emit 0x35
-		__emit 0x01
-		mov edx, [esi+48h]
-		push edx
-		__emit 0xff
-		__emit 0x15
-		__emit 0xd4
-		__emit 0x8e
-		__emit 0x35
-		__emit 0x01
-		pop esi
-		ret
-	}
+	typedef void *(*CreateThreadProc)(void *, unsigned long, unsigned long (__stdcall *)(BFMENetworkBackend *), BFMENetworkBackend *, unsigned long, unsigned long *);
+	typedef int (__stdcall *SetThreadPriorityProc)(void *, int);
+	typedef int (__stdcall *CloseHandleProc)(void *);
+
+	m_liveHandle = (*reinterpret_cast<CreateThreadProc *>(0x01359298))(
+		0, 0, BFMENetworkBackendThreadStart, this, 4, reinterpret_cast<unsigned long *>(reinterpret_cast<char *>(this) + 0x44));
+	(*reinterpret_cast<SetThreadPriorityProc *>(0x01358f20))(m_liveHandle, *reinterpret_cast<int *>(reinterpret_cast<char *>(this) + 0x4c));
+	(*reinterpret_cast<CloseHandleProc *>(0x01358ed4))(m_liveHandle);
 }
 
 extern "C" __declspec(naked) void __stdcall BFMENetworkBackendEventCallback(void *a0, void *a1, void *a2, void *a3, void *a4, void *a5, void *a6, void *a7, void *a8, void *a9)

--- a/Code/GameEngine/Source/GameNetwork/native_network.cpp
+++ b/Code/GameEngine/Source/GameNetwork/native_network.cpp
@@ -85,6 +85,42 @@ public:
 	char m_pad1c[0x0c];
 };
 
+class BFMENetworkThreadRunner
+{
+public:
+	virtual void v00();
+	virtual void v04();
+	virtual void v08();
+	virtual void v0c();
+	virtual void v10();
+	virtual void v14();
+	virtual void v18();
+	virtual void v1c();
+	virtual void v20();
+	virtual void v24();
+	virtual void v28();
+	virtual void v2c();
+	virtual void v30();
+	virtual void v34();
+	virtual void v38();
+	virtual void v3c();
+	virtual void v40();
+	virtual void v44();
+	virtual void v48();
+	virtual void v4c();
+	virtual void v50();
+	virtual void v54();
+	virtual void threadTick();
+};
+
+class BFMENetworkBackendThreadRunner
+{
+public:
+	virtual void v00();
+	virtual void v04();
+	virtual void dispatchEvents();
+};
+
 class BFMENetwork
 {
 public:
@@ -117,23 +153,12 @@ private:
 extern "C" __declspec(dllimport) unsigned long __stdcall WaitForSingleObject(void *handle, unsigned long milliseconds);
 extern "C" __declspec(dllimport) int __stdcall ReleaseMutex(void *handle);
 
-extern "C" __declspec(naked) unsigned long __stdcall BFMENetworkBackendThreadStart(BFMENetworkBackend *backend)
+extern "C" unsigned long __stdcall BFMENetworkBackendThreadStart(BFMENetworkBackend *backend)
 {
-	__asm {
-		__emit 0x8b
-		__emit 0x0d
-		__emit 0x5c
-		__emit 0x6e
-		__emit 0x33
-		__emit 0x01
-		mov eax, [ecx]
-		call dword ptr [eax+58h]
-		mov ecx, [esp+4]
-		mov edx, [ecx]
-		call dword ptr [edx+8]
-		xor eax, eax
-		ret 4
-	}
+	BFMENetworkThreadRunner *globalNetwork = *reinterpret_cast<BFMENetworkThreadRunner **>(0x01336e5c);
+	globalNetwork->threadTick();
+	reinterpret_cast<BFMENetworkBackendThreadRunner *>(backend)->dispatchEvents();
+	return 0;
 }
 
 // ?construct@BFMENetworkBackend@@QAEPAXPAVBFMENetworkLock@@@Z

--- a/Code/GameEngine/Source/GameNetwork/native_network_dispatcher.cpp
+++ b/Code/GameEngine/Source/GameNetwork/native_network_dispatcher.cpp
@@ -3451,14 +3451,7 @@ __declspec(naked) void BFMENetworkBackend::dispatchEvents()
 	}
 }
 
-extern "C" __declspec(naked) void BFMENetworkBackendDispatchCatch()
+extern "C" void *BFMENetworkBackendDispatchCatch()
 {
-	__asm {
-		__emit 0xb8
-		__emit 0xeb
-		__emit 0xca
-		__emit 0xa5
-		__emit 0x00
-		__emit 0xc3
-	}
+	return reinterpret_cast<void *>(0x00a5caeb);
 }


### PR DESCRIPTION
## Summary

This replaces several small raw byte/native asm stubs with equivalent C++:

- `ParticleSystemTemplate::setSlaveSystemName`
- `BFMENetRequestPlayerLeaveCommandMsg::construct`
- `BFMENetRequestPlayerLeaveCommandMsg::destruct`
- `BFMENetRequestPlayerLeaveCommandMsg::setRequestedPlayerID`
- `BFMENetRequestPlayerLeaveCommandMsg::getRequestedPlayerID`
- `_BFMENetworkBackendThreadStart@4`
- `_BFMENetworkBackendDispatchCatch`
- `BFMENetworkBackend::openLiveHandle`

The implementations keep the original layout behavior with explicit field offsets, vtable-shaped helper types, typed fixed-address returns, and typed import-pointer calls while removing hand-emitted instruction bytes from these small helpers.

## Validation

- Targeted verification passed for `ParticleSystemTemplate::setSlaveSystemName`.
- Targeted verification passed for all four `BFMENetRequestPlayerLeaveCommandMsg` methods.
- Targeted verification passed for `_BFMENetworkBackendThreadStart@4`.
- Targeted verification passed for `_BFMENetworkBackendDispatchCatch`.
- Targeted verification passed for `BFMENetworkBackend::openLiveHandle`.
- Source-file verification passed for the FX particle source: `279/279` functions matched.
- Source-file verification passed for the network command source: `4/4` functions matched.
- Source-file verification passed for the native network source: `23/23` functions matched.
- Source-file verification passed for the native network dispatcher source: `2/2` functions matched.
- CSV ledger check passed.
- Declared-function coverage check passed.

Note: full verification currently trips on unrelated case-colliding sweep shim headers in this macOS checkout, so this PR is validated with the targeted/source-file byte gates.
