### PR TITLE
Match W3DGameClient ray effect creation

### DIFF
--- a/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DGameClient.cpp
+++ b/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DGameClient.cpp
@@ -152,12 +152,17 @@ void W3DGameClient::addScorch(const Coord3D *pos, Real radius, Scorches type)
 //-------------------------------------------------------------------------------------------------
 /** create an effect that requires a start and end location */
 //-------------------------------------------------------------------------------------------------
-// ?createRayEffectByTemplate@W3DGameClient@@UAEXPBUCoord3D@@0PBVThingTemplate@@@Z present-unmatched
+class BFMEThingFactory : public ThingFactory
+{
+public:
+	Drawable *newDrawable(const ThingTemplate *tmplate, DrawableStatus statusBits, Int drawableID);
+};
+
 void W3DGameClient::createRayEffectByTemplate( const Coord3D *start, 
 																		 const Coord3D *end, 
 																		 const ThingTemplate* tmpl )
 {
-	Drawable *draw = TheThingFactory->newDrawable(tmpl);
+	Drawable *draw = ((BFMEThingFactory *)TheThingFactory)->newDrawable(tmpl, DRAWABLE_STATUS_NONE, -1);
 
 	if( draw )
 	{
@@ -243,5 +248,3 @@ void W3DGameClient::notifyTerrainObjectMoved(Object *obj)
 	}
 
 }  // end setTimeOfDay
-
-

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -8857,3 +8857,4 @@ _$E6,,0x00C70930,40,Code/Libraries/Source/WWVegas/WWMath/aabtreecull.cpp,matched
 ??4?$DynamicVectorClass@VStringClass@@@@QAEAAV0@ABV0@@Z,,0x00907320,33,Code/Libraries/Source/WWVegas/WWSaveLoad/parameter.cpp,matched,
 ??4?$DynamicVectorClass@U_ENUM_VALUE@EnumParameterClass@@@@QAEAAV0@ABV0@@Z,,0x00907320,33,Code/Libraries/Source/WWVegas/WWSaveLoad/parameter.cpp,matched,
 ?Create@?$SimpleDefinitionFactoryClass@VTwiddlerClass@@$0OAAA@$1?TwiddlerClassName@@3PADA@@UBEPAVDefinitionClass@@XZ,,0x006FB600,86,Code/Libraries/Source/WWVegas/WWSaveLoad/twiddler.cpp,matched,
+?createRayEffectByTemplate@W3DGameClient@@UAEXPBUCoord3D@@0PBVThingTemplate@@@Z,,0x006FBC00,129,Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DGameClient.cpp,matched,

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -3216,3 +3216,5 @@ __CIfmod,0x009F70CC,hit-decoded x4 (body)
 ??_ETexProjectClass@@UAEPAXI@Z,0x0004822F,pinharvest x1 (thunk)
 ??0TwiddlerClass@@QAE@XZ,0x000063A2,pinharvest x1 (thunk)
 ??0TwiddlerClass@@QAE@XZ,0x0000CDC9,pinharvest x1 (thunk)
+?newDrawable@BFMEThingFactory@@QAEPAVDrawable@@PBVThingTemplate@@W4DrawableStatus@@H@Z,0x0002C336
+?setPosition@Drawable@@QAEXPBUCoord3D@@@Z,0x0001742C


### PR DESCRIPTION
## Summary

- match `W3DGameClient::createRayEffectByTemplate` to the BFME 1.03 retail body
- expose the retail-only three-argument drawable creation call through a source-local BFME factory view
- record the corrected `0x006FBC00` function boundary, 129-byte size, and derived relocation pins

## Commit structure

- `f46bf868` — one byte-matching contribution for ray-effect drawable creation

## Verification

- pre-commit hook: `PRE-COMMIT OK`
- focused byte verification: `Functions: OK 10/10 matched across 1 source file(s)`
- string-reference verification: `OK`
- ledger integrity: `check_csv: OK (functions.csv 8859 rows, symbols.csv 3219 rows)`

## Full-suite note

The final source-only delta passes the repository's focused commit gate. A full 1,509-source audit was also compiled locally while evaluating an earlier header-based version, but this WSL/Wine checkout cannot complete the unrelated baseline verification because `ParabolicEase.cpp` emits a platform-specific anonymous-namespace hash (`0x9a89ad21` versus ledger `0x9e2c8049`). This PR does not touch that file.
