### PR TITLE
Match PopupMessageData destructor and ScienceType find

### DIFF
--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -8857,3 +8857,4 @@ _$E6,,0x00C70930,40,Code/Libraries/Source/WWVegas/WWMath/aabtreecull.cpp,matched
 ??4?$DynamicVectorClass@VStringClass@@@@QAEAAV0@ABV0@@Z,,0x00907320,33,Code/Libraries/Source/WWVegas/WWSaveLoad/parameter.cpp,matched,
 ??4?$DynamicVectorClass@U_ENUM_VALUE@EnumParameterClass@@@@QAEAAV0@ABV0@@Z,,0x00907320,33,Code/Libraries/Source/WWVegas/WWSaveLoad/parameter.cpp,matched,
 ?Create@?$SimpleDefinitionFactoryClass@VTwiddlerClass@@$0OAAA@$1?TwiddlerClassName@@3PADA@@UBEPAVDefinitionClass@@XZ,,0x006FB600,86,Code/Libraries/Source/WWVegas/WWSaveLoad/twiddler.cpp,matched,
+??_GPopupMessageData@@MAEPAXI@Z,,0x0078D240,30,Code/GameEngine/Source/GameClient/InGameUI.cpp,matched,

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -8858,3 +8858,4 @@ _$E6,,0x00C70930,40,Code/Libraries/Source/WWVegas/WWMath/aabtreecull.cpp,matched
 ??4?$DynamicVectorClass@U_ENUM_VALUE@EnumParameterClass@@@@QAEAAV0@ABV0@@Z,,0x00907320,33,Code/Libraries/Source/WWVegas/WWSaveLoad/parameter.cpp,matched,
 ?Create@?$SimpleDefinitionFactoryClass@VTwiddlerClass@@$0OAAA@$1?TwiddlerClassName@@3PADA@@UBEPAVDefinitionClass@@XZ,,0x006FB600,86,Code/Libraries/Source/WWVegas/WWSaveLoad/twiddler.cpp,matched,
 ??_GPopupMessageData@@MAEPAXI@Z,,0x0078D240,30,Code/GameEngine/Source/GameClient/InGameUI.cpp,matched,
+??$find@PBW4ScienceType@@W41@@_STL@@YAPBW4ScienceType@@PBW41@0ABW41@@Z,,0x000CD0A0,30,Code/GameEngine/Source/Common/RTS/Player.cpp,matched,

--- a/reverse/re_attempts.log
+++ b/reverse/re_attempts.log
@@ -1009,3 +1009,6 @@ _$E7	dead	absent from retail .text (masked body-scan over full segment, 0 hits)
 ?Save@LightClass@@UAE_NAAVChunkSaveClass@@@Z	no-match	not emitted in drift-attributed TU (wrong-source artifact of basename map); needs emission from another landed TU
 ?Load@LightClass@@UAE_NAAVChunkLoadClass@@@Z	no-match	not emitted in drift-attributed TU (wrong-source artifact of basename map); needs emission from another landed TU
 ??1MeshLoadContextClass@@EAE@XZ	no-match	not emitted in drift-attributed TU (wrong-source artifact of basename map); needs emission from another landed TU
+_$E28	no-match	Current VS2003 object emits only _$E9 and _$E10; _$E28 is absent, so this drift row is stale/compiler-numbering dependent.
+?emit_ArmorUpgrade@ModulePoolGlueBulk@@YAPAVModule@@PAVThing@@PBVModuleData@@@Z	dead	Corrected Ghidra boundary 0x11D090 is already claimed by matched ArmorUpgrade::friend_newModuleInstance; synthetic emitter is an ICF twin, not a separate retail function.
+_$E47	no-match	Current VS2003 object emits _$E14/15/17/18/20/21/23/24; _$E47 is absent, so this static-initializer drift row is stale/compiler-numbering dependent.


### PR DESCRIPTION
## Summary

- match `PopupMessageData`'s scalar deleting destructor at `0x0078D240` (30 bytes)
- match the specialized STL `find` helper for `ScienceType` pointers at `0x000CD0A0` (30 bytes)
- record three exhausted structural candidates so future contributors do not repeat the same analysis

Each matched function is isolated in its own commit.

## Commits

- `96935a2b` — match `PopupMessageData` scalar deleting destructor
- `063ce06c` — match `ScienceType` pointer `find` helper

## Focused verification

- `InGameUI.cpp`: `Functions: OK 27/27`; string-reference verification OK
- `Player.cpp`: `Functions: OK 52/52`; string-reference verification OK
- ledger integrity: `check_csv: OK (functions.csv 8860 rows, symbols.csv 3217 rows)`
- both pre-commit hooks: `PRE-COMMIT OK`

## Full-suite qualification

The reused WSL object cache completed `Functions: OK 8860/8860` across 1,509 source files and verified all 976 string references. Its final DIR32 consistency stage reported 12 unrelated inconsistent symbols from earlier temporary include-layout experiments, so I am leaving this as a draft and not claiming an entirely clean full gate. This PR changes only the function ledger and attempt log; both outgoing deltas pass their repository hooks.
