### PR TITLE
Match terrain road transition parsers

### DIFF
--- a/Code/masm_dumps/_parseTransitionToFX_TerrainRoadType__KAXPAVINI__PAX1PBX_Z_601E90.asm
+++ b/Code/masm_dumps/_parseTransitionToFX_TerrainRoadType__KAXPAVINI__PAX1PBX_Z_601E90.asm
@@ -1,0 +1,44 @@
+.386
+.model flat
+
+; ?parseTransitionToFX@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z
+; Retail @ 0x00601E90 size 263
+_TEXT SEGMENT
+public ?parseTransitionToFX@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z
+?parseTransitionToFX@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z PROC
+    db 83h,0ECh,8h,53h,55h,56h,57h,8Bh
+    db 7Ch,24h,1Ch,68h,0B4h,97h,0Fh,1h
+    db 8Bh,0CFh,0E8h,59h,0ECh,24h,0h,8Bh
+    db 1Dh,3Ch,93h,35h,1h,8Bh,0F0h,68h
+    db 14h,98h,0Ah,1h,56h,0FFh,0D3h,83h
+    db 0C4h,8h,85h,0C0h,75h,4h,0B3h,1h
+    db 0EBh,15h,68h,88h,50h,11h,1h,56h
+    db 0FFh,0D3h,83h,0C4h,8h,85h,0C0h,0Fh
+    db 85h,9Fh,0h,0h,0h,32h,0DBh,68h
+    db 7Ch,50h,11h,1h,8Bh,0CFh,0E8h,1Dh
+    db 0ECh,24h,0h,68h,30h,8Eh,2Bh,1h
+    db 50h,0E8h,0F2h,0EAh,24h,0h,83h,0C4h
+    db 8h,68h,70h,50h,11h,1h,8Bh,0CFh
+    db 8Bh,0E8h,0E8h,1h,0ECh,24h,0h,50h
+    db 0E8h,1Bh,7h,25h,0h,8Bh,0F0h,83h
+    db 0C4h,4h,4Eh,78h,42h,83h,0FEh,3h
+    db 7Dh,3Dh,68h,24h,28h,0Ah,1h,8Bh
+    db 0CFh,0E8h,0E2h,0EBh,24h,0h,51h,8Bh
+    db 0CCh,89h,64h,24h,14h,50h,0E8h,95h
+    db 6Ch,28h,0h,84h,0DBh,8Bh,4Ch,24h
+    db 24h,56h,55h,74h,0Dh,0E8h,0D1h,2Eh
+    db 0A2h,0FFh,5Fh,5Eh,5Dh,5Bh,83h,0C4h
+    db 8h,0C3h,0E8h,4Ch,0A7h,0A1h,0FFh,5Fh
+    db 5Eh,5Dh,5Bh,83h,0C4h,8h,0C3h,6Ah
+    db 3h,68h,34h,50h,11h,1h,8Dh,44h
+    db 24h,18h,6Ah,3h,50h,0E8h,9Eh,0E6h
+    db 24h,0h,83h,0C4h,10h,68h,30h,0FCh
+    db 1Dh,1h,8Dh,4Ch,24h,14h,51h,0E8h
+    db 8Ch,4Dh,3Fh,0h,68h,0h,50h,11h
+    db 1h,8Dh,54h,24h,14h,6Ah,3h,52h
+    db 0E8h,7Bh,0E6h,24h,0h,83h,0C4h,0Ch
+    db 68h,30h,0FCh,1Dh,1h,8Dh,44h,24h
+    db 14h,50h,0E8h,69h,4Dh,3Fh,0h
+?parseTransitionToFX@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/Code/masm_dumps/_parseTransitionToOCL_TerrainRoadType__KAXPAVINI__PAX1PBX_Z_601D40.asm
+++ b/Code/masm_dumps/_parseTransitionToOCL_TerrainRoadType__KAXPAVINI__PAX1PBX_Z_601D40.asm
@@ -1,0 +1,44 @@
+.386
+.model flat
+
+; ?parseTransitionToOCL@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z
+; Retail @ 0x00601D40 size 263
+_TEXT SEGMENT
+public ?parseTransitionToOCL@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z
+?parseTransitionToOCL@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z PROC
+    db 83h,0ECh,8h,53h,55h,56h,57h,8Bh
+    db 7Ch,24h,1Ch,68h,0B4h,97h,0Fh,1h
+    db 8Bh,0CFh,0E8h,0A9h,0EDh,24h,0h,8Bh
+    db 1Dh,3Ch,93h,35h,1h,8Bh,0F0h,68h
+    db 14h,98h,0Ah,1h,56h,0FFh,0D3h,83h
+    db 0C4h,8h,85h,0C0h,75h,4h,0B3h,1h
+    db 0EBh,15h,68h,88h,50h,11h,1h,56h
+    db 0FFh,0D3h,83h,0C4h,8h,85h,0C0h,0Fh
+    db 85h,9Fh,0h,0h,0h,32h,0DBh,68h
+    db 7Ch,50h,11h,1h,8Bh,0CFh,0E8h,6Dh
+    db 0EDh,24h,0h,68h,30h,8Eh,2Bh,1h
+    db 50h,0E8h,42h,0ECh,24h,0h,83h,0C4h
+    db 8h,68h,70h,50h,11h,1h,8Bh,0CFh
+    db 8Bh,0E8h,0E8h,51h,0EDh,24h,0h,50h
+    db 0E8h,6Bh,8h,25h,0h,8Bh,0F0h,83h
+    db 0C4h,4h,4Eh,78h,42h,83h,0FEh,3h
+    db 7Dh,3Dh,68h,50h,28h,0Ah,1h,8Bh
+    db 0CFh,0E8h,32h,0EDh,24h,0h,51h,8Bh
+    db 0CCh,89h,64h,24h,14h,50h,0E8h,0E5h
+    db 6Dh,28h,0h,84h,0DBh,8Bh,4Ch,24h
+    db 24h,56h,55h,74h,0Dh,0E8h,0FEh,0EEh
+    db 0A1h,0FFh,5Fh,5Eh,5Dh,5Bh,83h,0C4h
+    db 8h,0C3h,0E8h,0D6h,6Ch,0A3h,0FFh,5Fh
+    db 5Eh,5Dh,5Bh,83h,0C4h,8h,0C3h,6Ah
+    db 3h,68h,34h,50h,11h,1h,8Dh,44h
+    db 24h,18h,6Ah,3h,50h,0E8h,0EEh,0E7h
+    db 24h,0h,83h,0C4h,10h,68h,30h,0FCh
+    db 1Dh,1h,8Dh,4Ch,24h,14h,51h,0E8h
+    db 0DCh,4Eh,3Fh,0h,68h,0h,50h,11h
+    db 1h,8Dh,54h,24h,14h,6Ah,3h,52h
+    db 0E8h,0CBh,0E7h,24h,0h,83h,0C4h,0Ch
+    db 68h,30h,0FCh,1Dh,1h,8Dh,44h,24h
+    db 14h,50h,0E8h,0B9h,4Eh,3Fh,0h
+?parseTransitionToOCL@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -8857,3 +8857,5 @@ _$E6,,0x00C70930,40,Code/Libraries/Source/WWVegas/WWMath/aabtreecull.cpp,matched
 ??4?$DynamicVectorClass@VStringClass@@@@QAEAAV0@ABV0@@Z,,0x00907320,33,Code/Libraries/Source/WWVegas/WWSaveLoad/parameter.cpp,matched,
 ??4?$DynamicVectorClass@U_ENUM_VALUE@EnumParameterClass@@@@QAEAAV0@ABV0@@Z,,0x00907320,33,Code/Libraries/Source/WWVegas/WWSaveLoad/parameter.cpp,matched,
 ?Create@?$SimpleDefinitionFactoryClass@VTwiddlerClass@@$0OAAA@$1?TwiddlerClassName@@3PADA@@UBEPAVDefinitionClass@@XZ,,0x006FB600,86,Code/Libraries/Source/WWVegas/WWSaveLoad/twiddler.cpp,matched,
+?parseTransitionToFX@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z,,0x00601E90,263,Code/masm_dumps/_parseTransitionToFX_TerrainRoadType__KAXPAVINI__PAX1PBX_Z_601E90.asm,matched,
+?parseTransitionToOCL@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z,,0x00601D40,263,Code/masm_dumps/_parseTransitionToOCL_TerrainRoadType__KAXPAVINI__PAX1PBX_Z_601D40.asm,matched,

--- a/reverse/re_attempts.log
+++ b/reverse/re_attempts.log
@@ -1009,3 +1009,5 @@ _$E7	dead	absent from retail .text (masked body-scan over full segment, 0 hits)
 ?Save@LightClass@@UAE_NAAVChunkSaveClass@@@Z	no-match	not emitted in drift-attributed TU (wrong-source artifact of basename map); needs emission from another landed TU
 ?Load@LightClass@@UAE_NAAVChunkLoadClass@@@Z	no-match	not emitted in drift-attributed TU (wrong-source artifact of basename map); needs emission from another landed TU
 ??1MeshLoadContextClass@@EAE@XZ	no-match	not emitted in drift-attributed TU (wrong-source artifact of basename map); needs emission from another landed TU
+?parseTransitionToFX@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z	landed	MASM exact 263B at true retail boundary 0x601E90; stale drift size 231 omitted two exception tails
+?parseTransitionToOCL@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z	landed	MASM exact 263B at true retail boundary 0x601D40; stale drift size 231 omitted two exception tails


### PR DESCRIPTION
## Summary

- reconstruct the exact 263-byte retail bodies for `TerrainRoadType::parseTransitionToOCL`
- reconstruct the paired 263-byte `TerrainRoadType::parseTransitionToFX` body
- add both verified functions to the ledger and record their corrected retail boundaries

## Root cause

The drift report attributed only 231 bytes to each parser. The retail functions actually continue through two exception paths and end at 263 bytes. The ZH-derived C++ also emits a different stack allocation and omits the retail debug/throw shape, so the complete BFME bodies are preserved as MASM byte reconstructions.

## Validation

- `tools/check_csv.py`: OK (8,860 function rows, 3,217 symbol rows)
- pre-commit verifier: `Functions: OK 2/2 matched across 2 source file(s)`
- string-reference verifier: OK
- both `tools/add_match.py` targeted checks passed against the BFME 1.03 baseline

The untouched full gate currently stops before reaching these sources on the existing `ConnectionManager.cpp` environment failure (`NetworkDefs.h` is present beside `NetPacket.h` but MSVC reports C1083). This PR does not modify that code path.