### PR TITLE
Fix stale ZH sweep candidate filtering

### DIFF
--- a/tools/land_zh.py
+++ b/tools/land_zh.py
@@ -32,6 +32,7 @@ DEST = ROOT / "Code"
 REF_REL = "reference/CnC_Generals_Zero_Hour/GeneralsMD/Code"
 HEAD = (
     f"// cl: /DNDEBUG /DWIN32 /D_WINDOWS /MD /EHsc /Ireference/shims/sweep /I{REF_REL}/GameEngine/Include"
+    f" /I{REF_REL}/GameEngine/Include/GameNetwork"
     f" /I{REF_REL}/GameEngine/Source /I{REF_REL}/Libraries/Include /I{REF_REL}/Libraries/Source"
     f" /I{REF_REL}/Libraries/Source/Compression /I{REF_REL}/Libraries/Source/debug"
     f" /I{REF_REL}/Libraries/Source/WWVegas /I{REF_REL}/Libraries/Source/WWVegas/WWLib"
@@ -51,7 +52,11 @@ def land(name, dry_run=False):
         print(f"{name}: FAIL — no reference file {name}.cpp under {REF.relative_to(ROOT)}")
         return False
     dest = DEST / hits[0].relative_to(REF)
-    if dest.exists():
+    existing = next(
+        (path for path in dest.parent.glob("*.cpp") if path.name.casefold() == dest.name.casefold()),
+        None,
+    )
+    if existing is not None:
         print(f"{name}: SKIP — {dest.relative_to(ROOT)} already exists (already landed)")
         return True
     if dry_run:

--- a/tools/next_work.py
+++ b/tools/next_work.py
@@ -117,7 +117,12 @@ def sweep_winners(mine):
     last = {}
     for row in rows:
         last[row["file"]] = row
-    ported = {p.stem.lower() for p in (ROOT / "src" / "zh").glob("*.cpp")}
+    legacy_ported = {p.stem.casefold() for p in (ROOT / "src" / "zh").glob("*.cpp")}
+    code_root = ROOT / "Code"
+    landed_paths = {
+        p.relative_to(code_root).as_posix().casefold()
+        for p in code_root.rglob("*.cpp")
+    }
     out = []
     for file, row in last.items():
         if row["status"] != "ok":
@@ -125,7 +130,10 @@ def sweep_winners(mine):
         score = (to_int(row["landable"], 10, f"report.csv landable for {file}")
                  if has_landable and row.get("landable", "") != ""
                  else to_int(row["located"], 10, f"report.csv located for {file}"))
-        if score < 1 or Path(file).stem.lower() in ported or not mine(file):
+        if (score < 1
+                or Path(file).stem.casefold() in legacy_ported
+                or file.casefold() in landed_paths
+                or not mine(file)):
             continue
         if not (REF / file).exists():
             print(f"warning: report.csv names a missing reference file, skipped: {file}",

--- a/tools/sweep_generalsmd.py
+++ b/tools/sweep_generalsmd.py
@@ -63,7 +63,12 @@ HEAD = "// cl: /DNDEBUG /DWIN32 /D_WINDOWS /MD /EHsc\n// stlport\n#define Matrix
 
 
 def candidates(area, names):
-    ported = {p.stem.lower() for p in ROOT.glob("src/**/*.cpp")}
+    legacy_ported = {p.stem.casefold() for p in ROOT.glob("src/**/*.cpp")}
+    code_root = ROOT / "Code"
+    landed_paths = {
+        p.relative_to(code_root).as_posix().casefold()
+        for p in code_root.rglob("*.cpp")
+    }
     if names:
         out = []
         for name in names:
@@ -74,8 +79,13 @@ def candidates(area, names):
                 print(f"  no reference file named {stem}.cpp")
             out += hits
         return out
-    return [p for p in sorted((REF / area).rglob("*.cpp"))
-            if p.stem.lower() not in ported and not p.name.startswith(".sweep_")]
+    return [
+        p
+        for p in sorted((REF / area).rglob("*.cpp"))
+        if p.stem.casefold() not in legacy_ported
+        and p.relative_to(REF).as_posix().casefold() not in landed_paths
+        and not p.name.startswith(".sweep_")
+    ]
 
 
 def sweep_one(ref_cpp):

--- a/tools/sweep_generalsmd.py
+++ b/tools/sweep_generalsmd.py
@@ -43,6 +43,7 @@ REPORT_FIELDS = ["file", "status", "located", "ambiguous", "unlocated", "blocker
 INCLUDE_DIRS = [
     SHIMS,
     REF / "GameEngine" / "Include",
+    REF / "GameEngine" / "Include" / "GameNetwork",
     REF / "GameEngine" / "Source",
     REF / "Libraries" / "Include",
     REF / "Libraries" / "Source",

--- a/tools/tests/test_next_work.py
+++ b/tools/tests/test_next_work.py
@@ -78,8 +78,12 @@ def test_sweep_winners_validated(data):
     for c in data["sweep_winners"]:
         ref = REF / c["file"]
         assert ref.exists(), f"candidate reference file missing: {ref}"
-        dest = ROOT / "src" / "zh" / (Path(c["file"]).stem.lower() + ".cpp")
-        assert not dest.exists(), f"candidate already landed: {dest}"
+        legacy_dest = ROOT / "src" / "zh" / (Path(c["file"]).stem.lower() + ".cpp")
+        assert not legacy_dest.exists(), f"candidate already landed: {legacy_dest}"
+        code_rel = Path(*Path(c["file"]).parts)
+        code_dest = ROOT / "Code" / code_rel
+        code_siblings = {p.name.casefold() for p in code_dest.parent.glob("*.cpp")}
+        assert code_dest.name.casefold() not in code_siblings, f"candidate already landed: {code_dest}"
         assert c["command"].startswith("python3 tools/land_zh.py "), c["command"]
         assert c["landable"] >= 1, f"unlandable candidate listed: {c}"
     print(f"PASS sweep winners validated: {len(data['sweep_winners'])} candidates, "


### PR DESCRIPTION
## What changed

- add the GameNetwork include directory to both ZH sweep and landing compile recipes
- make `land_zh.py` detect case-only duplicate source paths on case-sensitive filesystems
- exclude sources already landed under `Code/` from fresh sweeps and the next-work queue
- extend the next-work regression test to cover current `Code/` landings

## Why

The stale sweep report advertised 195 landable files, but all 195 were already present under `Code/`. GameNetwork candidates also stopped at `NetworkDefs.h`, and Linux could attempt a duplicate `NAT.cpp` beside the existing `nat.cpp`.

These fixes make the queue reflect genuine remaining work and let GameNetwork sources reach function comparison.

## Validation

- `python3 -m py_compile tools/land_zh.py tools/sweep_generalsmd.py tools/next_work.py`
- `python3 tools/check_csv.py`
- `python3 tools/tests/test_next_work.py`
- fresh bounded GameNetwork sweep: `NetworkDefs.h` blocker removed
- `python3 tools/next_work.py`: sweep winners reduced from 195 stale entries to 0 current entries
