### PR TITLE
Match 12 device-side Ghidra aliases

### DIFF
--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10165,3 +10165,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?GadgetCheckBoxGetEnabledUncheckedBoxColor@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DCheckBox.cpp,matched,tiny-locate
 ?GadgetComboBoxGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DComboBox.cpp,matched,tiny-locate
 ?GadgetListBoxGetEnabledSelectedItemColor@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DListBox.cpp,matched,tiny-locate
+?GadgetProgressBarGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DProgressBar.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10163,3 +10163,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?ClearStatus@UDP@@QAEXXZ,,0x006DF1E0,8,Code/GameEngine/Source/GameNetwork/udp.cpp,matched,tiny-locate
 ?GadgetCheckBoxGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DCheckBox.cpp,matched,tiny-locate
 ?GadgetCheckBoxGetEnabledUncheckedBoxColor@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DCheckBox.cpp,matched,tiny-locate
+?GadgetComboBoxGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DComboBox.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10169,3 +10169,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?GadgetButtonGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DPushButton.cpp,matched,tiny-locate
 ?GadgetRadioGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DRadioButton.cpp,matched,tiny-locate
 ?GadgetRadioGetEnabledUncheckedBoxColor@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DRadioButton.cpp,matched,tiny-locate
+?GadgetStaticTextGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DStaticText.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10164,3 +10164,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?GadgetCheckBoxGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DCheckBox.cpp,matched,tiny-locate
 ?GadgetCheckBoxGetEnabledUncheckedBoxColor@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DCheckBox.cpp,matched,tiny-locate
 ?GadgetComboBoxGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DComboBox.cpp,matched,tiny-locate
+?GadgetListBoxGetEnabledSelectedItemColor@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DListBox.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10159,3 +10159,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?empty@?$map@GEU?$less@G@_STL@@V?$allocator@U?$pair@$$CBGE@_STL@@@2@@_STL@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp,matched,tiny-locate
 ?isOpen@GameSlot@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/GameInfo.cpp,matched,tiny-locate
 ?empty@?$_Rb_tree@PAVGameWindow@@PAV1@U?$_Identity@PAVGameWindow@@@_STL@@U?$less@PAVGameWindow@@@3@V?$allocator@PAVGameWindow@@@3@@_STL@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/GameSpy/Chat.cpp,matched,tiny-locate
+?empty@?$set@PAVGameWindow@@U?$less@PAVGameWindow@@@_STL@@V?$allocator@PAVGameWindow@@@3@@_STL@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/GameSpy/Chat.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10168,3 +10168,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?GadgetProgressBarGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DProgressBar.cpp,matched,tiny-locate
 ?GadgetButtonGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DPushButton.cpp,matched,tiny-locate
 ?GadgetRadioGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DRadioButton.cpp,matched,tiny-locate
+?GadgetRadioGetEnabledUncheckedBoxColor@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DRadioButton.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10167,3 +10167,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?GadgetListBoxGetEnabledSelectedItemColor@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DListBox.cpp,matched,tiny-locate
 ?GadgetProgressBarGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DProgressBar.cpp,matched,tiny-locate
 ?GadgetButtonGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DPushButton.cpp,matched,tiny-locate
+?GadgetRadioGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DRadioButton.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10161,3 +10161,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?empty@?$_Rb_tree@PAVGameWindow@@PAV1@U?$_Identity@PAVGameWindow@@@_STL@@U?$less@PAVGameWindow@@@3@V?$allocator@PAVGameWindow@@@3@@_STL@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/GameSpy/Chat.cpp,matched,tiny-locate
 ?empty@?$set@PAVGameWindow@@U?$less@PAVGameWindow@@@_STL@@V?$allocator@PAVGameWindow@@@3@@_STL@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/GameSpy/Chat.cpp,matched,tiny-locate
 ?ClearStatus@UDP@@QAEXXZ,,0x006DF1E0,8,Code/GameEngine/Source/GameNetwork/udp.cpp,matched,tiny-locate
+?GadgetCheckBoxGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DCheckBox.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10160,3 +10160,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?isOpen@GameSlot@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/GameInfo.cpp,matched,tiny-locate
 ?empty@?$_Rb_tree@PAVGameWindow@@PAV1@U?$_Identity@PAVGameWindow@@@_STL@@U?$less@PAVGameWindow@@@3@V?$allocator@PAVGameWindow@@@3@@_STL@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/GameSpy/Chat.cpp,matched,tiny-locate
 ?empty@?$set@PAVGameWindow@@U?$less@PAVGameWindow@@@_STL@@V?$allocator@PAVGameWindow@@@3@@_STL@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/GameSpy/Chat.cpp,matched,tiny-locate
+?ClearStatus@UDP@@QAEXXZ,,0x006DF1E0,8,Code/GameEngine/Source/GameNetwork/udp.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10166,3 +10166,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?GadgetComboBoxGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DComboBox.cpp,matched,tiny-locate
 ?GadgetListBoxGetEnabledSelectedItemColor@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DListBox.cpp,matched,tiny-locate
 ?GadgetProgressBarGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DProgressBar.cpp,matched,tiny-locate
+?GadgetButtonGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DPushButton.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10158,3 +10158,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?empty@?$_Rb_tree@GU?$pair@$$CBGE@_STL@@U?$_Select1st@U?$pair@$$CBGE@_STL@@@2@U?$less@G@2@V?$allocator@U?$pair@$$CBGE@_STL@@@2@@_STL@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp,matched,tiny-locate
 ?empty@?$map@GEU?$less@G@_STL@@V?$allocator@U?$pair@$$CBGE@_STL@@@2@@_STL@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp,matched,tiny-locate
 ?isOpen@GameSlot@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/GameInfo.cpp,matched,tiny-locate
+?empty@?$_Rb_tree@PAVGameWindow@@PAV1@U?$_Identity@PAVGameWindow@@@_STL@@U?$less@PAVGameWindow@@@3@V?$allocator@PAVGameWindow@@@3@@_STL@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/GameSpy/Chat.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10162,3 +10162,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?empty@?$set@PAVGameWindow@@U?$less@PAVGameWindow@@@_STL@@V?$allocator@PAVGameWindow@@@3@@_STL@@QBE_NXZ,,0x0061E630,11,Code/GameEngine/Source/GameNetwork/GameSpy/Chat.cpp,matched,tiny-locate
 ?ClearStatus@UDP@@QAEXXZ,,0x006DF1E0,8,Code/GameEngine/Source/GameNetwork/udp.cpp,matched,tiny-locate
 ?GadgetCheckBoxGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DCheckBox.cpp,matched,tiny-locate
+?GadgetCheckBoxGetEnabledUncheckedBoxColor@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DCheckBox.cpp,matched,tiny-locate


### PR DESCRIPTION
## Summary

- add 12 exact tiny-function aliases discovered from cached VC7 objects
- require every target to start at an exact Ghidra function boundary with Ghidra's exact size
- advance the verified ledger from 10,159 to 10,171 rows

## Commit structure

Each of the 12 commits is one contribution: one matched `reverse/functions.csv` row.

## Validation

- `python3 tools/check_csv.py`: OK (`functions.csv` 10,171 rows; `symbols.csv` 3,265 rows)
- every normal commit hook: ledger integrity plus focused byte verification
- interval audit: 12 commits checked, 0 malformed; each adds exactly one ledger row and changes exactly one file
- Ghidra boundary audit: 12/12 exact (`GHIDRA=12`, `BAD=0`)
- combined tranche gate: `Functions: OK 115/115 matched across 9 source file(s)`; string-ref verification OK
- local and upstream branch heads match at `511ae2df45b0c7517e7bdc3867f25eefdab01004`

The full repository gate was not rerun for this small tranche because the shared Wine environment remains unstable under whole-tree compilation. The focused combined gate and every contribution-level hook are green.
