### PR TITLE
Exhaust Ghidra-boundary tiny alias pool

### DIFF
--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10170,3 +10170,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?GadgetRadioGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DRadioButton.cpp,matched,tiny-locate
 ?GadgetRadioGetEnabledUncheckedBoxColor@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DRadioButton.cpp,matched,tiny-locate
 ?GadgetStaticTextGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DStaticText.cpp,matched,tiny-locate
+?GadgetTabControlGetEnabledColorTabZero@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DTabControl.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10178,3 +10178,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ??0AAPlaneClass@@QAE@W4AxisEnum@0@M@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/aabtreebuilder.cpp,matched,tiny-locate
 ??0MorphKeyStruct@TimeCodedMorphKeysClass@@QAE@KK@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.cpp,matched,tiny-locate
 ??0LODHeapNode@@QAE@PAVRenderObjClass@@M@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/predlod.cpp,matched,tiny-locate
+??0Random3Class@@QAE@II@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/seglinerenderer.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10174,3 +10174,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?GadgetTextEntryGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DTextEntry.cpp,matched,tiny-locate
 ?init@W3DShadowGeometry@@QAEHPAVRenderObjClass@@@Z,,0x00464830,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp,matched,tiny-locate
 ?update256@AlphaEdgeTextureClass@@IAEHPAVWorldHeightMap@@@Z,,0x00464830,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp,matched,tiny-locate
+?Reset@ClipPolyClass@@QAEXXZ,,0x00702070,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DPoly.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10181,3 +10181,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ??0Random3Class@@QAE@II@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/seglinerenderer.cpp,matched,tiny-locate
 ??0Edge@Strip@@QAE@HH@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/stripoptimizer.cpp,matched,tiny-locate
 ?Reset@VisPolyClass@@QAEXXZ,,0x00702070,8,Code/Libraries/Source/WWVegas/WW3D2/visrasterizer.cpp,matched,tiny-locate
+?Is_Done@GridListIterator@@QAE_NXZ,,0x0061E630,11,Code/Libraries/Source/WWVegas/WWMath/gridcull.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10177,3 +10177,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?Reset@ClipPolyClass@@QAEXXZ,,0x00702070,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DPoly.cpp,matched,tiny-locate
 ??0AAPlaneClass@@QAE@W4AxisEnum@0@M@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/aabtreebuilder.cpp,matched,tiny-locate
 ??0MorphKeyStruct@TimeCodedMorphKeysClass@@QAE@KK@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.cpp,matched,tiny-locate
+??0LODHeapNode@@QAE@PAVRenderObjClass@@M@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/predlod.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10171,3 +10171,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?GadgetRadioGetEnabledUncheckedBoxColor@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DRadioButton.cpp,matched,tiny-locate
 ?GadgetStaticTextGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DStaticText.cpp,matched,tiny-locate
 ?GadgetTabControlGetEnabledColorTabZero@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DTabControl.cpp,matched,tiny-locate
+?GadgetTextEntryGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DTextEntry.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10176,3 +10176,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?update256@AlphaEdgeTextureClass@@IAEHPAVWorldHeightMap@@@Z,,0x00464830,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp,matched,tiny-locate
 ?Reset@ClipPolyClass@@QAEXXZ,,0x00702070,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DPoly.cpp,matched,tiny-locate
 ??0AAPlaneClass@@QAE@W4AxisEnum@0@M@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/aabtreebuilder.cpp,matched,tiny-locate
+??0MorphKeyStruct@TimeCodedMorphKeysClass@@QAE@KK@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10175,3 +10175,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?init@W3DShadowGeometry@@QAEHPAVRenderObjClass@@@Z,,0x00464830,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp,matched,tiny-locate
 ?update256@AlphaEdgeTextureClass@@IAEHPAVWorldHeightMap@@@Z,,0x00464830,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp,matched,tiny-locate
 ?Reset@ClipPolyClass@@QAEXXZ,,0x00702070,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DPoly.cpp,matched,tiny-locate
+??0AAPlaneClass@@QAE@W4AxisEnum@0@M@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/aabtreebuilder.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10182,3 +10182,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ??0Edge@Strip@@QAE@HH@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/stripoptimizer.cpp,matched,tiny-locate
 ?Reset@VisPolyClass@@QAEXXZ,,0x00702070,8,Code/Libraries/Source/WWVegas/WW3D2/visrasterizer.cpp,matched,tiny-locate
 ?Is_Done@GridListIterator@@QAE_NXZ,,0x0061E630,11,Code/Libraries/Source/WWVegas/WWMath/gridcull.cpp,matched,tiny-locate
+??0PtrPairStruct@PointerRemapClass@@QAE@PAX0@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WWSaveLoad/pointerremap.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10173,3 +10173,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?GadgetTabControlGetEnabledColorTabZero@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DTabControl.cpp,matched,tiny-locate
 ?GadgetTextEntryGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DTextEntry.cpp,matched,tiny-locate
 ?init@W3DShadowGeometry@@QAEHPAVRenderObjClass@@@Z,,0x00464830,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp,matched,tiny-locate
+?update256@AlphaEdgeTextureClass@@IAEHPAVWorldHeightMap@@@Z,,0x00464830,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10180,3 +10180,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ??0LODHeapNode@@QAE@PAVRenderObjClass@@M@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/predlod.cpp,matched,tiny-locate
 ??0Random3Class@@QAE@II@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/seglinerenderer.cpp,matched,tiny-locate
 ??0Edge@Strip@@QAE@HH@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/stripoptimizer.cpp,matched,tiny-locate
+?Reset@VisPolyClass@@QAEXXZ,,0x00702070,8,Code/Libraries/Source/WWVegas/WW3D2/visrasterizer.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10172,3 +10172,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?GadgetStaticTextGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DStaticText.cpp,matched,tiny-locate
 ?GadgetTabControlGetEnabledColorTabZero@@YAHPAVGameWindow@@@Z,,0x00857460,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DTabControl.cpp,matched,tiny-locate
 ?GadgetTextEntryGetEnabledColor@@YAHPAVGameWindow@@@Z,,0x00857200,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DTextEntry.cpp,matched,tiny-locate
+?init@W3DShadowGeometry@@QAEHPAVRenderObjClass@@@Z,,0x00464830,8,Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp,matched,tiny-locate

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10179,3 +10179,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ??0MorphKeyStruct@TimeCodedMorphKeysClass@@QAE@KK@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.cpp,matched,tiny-locate
 ??0LODHeapNode@@QAE@PAVRenderObjClass@@M@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/predlod.cpp,matched,tiny-locate
 ??0Random3Class@@QAE@II@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/seglinerenderer.cpp,matched,tiny-locate
+??0Edge@Strip@@QAE@HH@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WW3D2/stripoptimizer.cpp,matched,tiny-locate


### PR DESCRIPTION
## Summary

- add the final 13 exact tiny-function aliases from the current cached-object discovery pool
- require every target to start at an exact Ghidra function boundary with Ghidra's exact size
- advance the verified ledger from 10,171 to 10,184 rows
- rerun the Ghidra-constrained discovery probe and confirm the pool is exhausted (`HITS=0`)

## Commit structure

Each of the 13 commits is one contribution: one matched `reverse/functions.csv` row.

## Validation

- `python3 tools/check_csv.py`: OK (`functions.csv` 10,184 rows; `symbols.csv` 3,265 rows)
- every normal commit hook: ledger integrity plus focused byte verification
- interval audit: 13 commits checked, 0 malformed; each adds exactly one ledger row and changes exactly one file
- Ghidra boundary audit: 13/13 exact (`GHIDRA=13`, `BAD=0`)
- combined tranche gate: `Functions: OK 266/266 matched across 13 source file(s)`; string-ref verification OK
- post-tranche discovery: `OBJECTS=627`, `TINY=17,584`, `HITS=0`
- local and upstream branch heads match at `675c87c86686ac2d0bc0a49a6117a501996fc217`

The full repository gate was not rerun for this small tranche because the shared Wine environment remains unstable under whole-tree compilation. The focused combined gate and every contribution-level hook are green.
