### PR TITLE
Match CameraClass destructor

### DIFF
--- a/Code/Libraries/Source/WWVegas/WW3D2/camera.cpp
+++ b/Code/Libraries/Source/WWVegas/WW3D2/camera.cpp
@@ -191,7 +191,6 @@ CameraClass & CameraClass::operator = (const CameraClass & that)
  * HISTORY:                                                                                    *
  *   3/21/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-// ??1CameraClass@@UAE@XZ present-unmatched
 CameraClass::~CameraClass(void)
 {
 }

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10183,3 +10183,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?Reset@VisPolyClass@@QAEXXZ,,0x00702070,8,Code/Libraries/Source/WWVegas/WW3D2/visrasterizer.cpp,matched,tiny-locate
 ?Is_Done@GridListIterator@@QAE_NXZ,,0x0061E630,11,Code/Libraries/Source/WWVegas/WWMath/gridcull.cpp,matched,tiny-locate
 ??0PtrPairStruct@PointerRemapClass@@QAE@PAX0@Z,,0x009E5EB0,18,Code/Libraries/Source/WWVegas/WWSaveLoad/pointerremap.cpp,matched,tiny-locate
+??1CameraClass@@UAE@XZ,,0x009312D0,18,Code/Libraries/Source/WWVegas/WW3D2/camera.cpp,matched,Ghidra vtable xrefs identified exact function

--- a/reverse/re_attempts.log
+++ b/reverse/re_attempts.log
@@ -1023,3 +1023,4 @@ _$E28	no-match	Current VS2003 object emits only _$E9 and _$E10; _$E28 is absent,
 _$E47	no-match	Current VS2003 object emits _$E14/15/17/18/20/21/23/24; _$E47 is absent, so this static-initializer drift row is stale/compiler-numbering dependent.
 ?parseTransitionToFX@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z	landed	MASM exact 263B at true retail boundary 0x601E90; stale drift size 231 omitted two exception tails
 ?parseTransitionToOCL@TerrainRoadType@@KAXPAVINI@@PAX1PBX@Z	landed	MASM exact 263B at true retail boundary 0x601D40; stale drift size 231 omitted two exception tails
+??1CameraClass@@UAE@XZ	landed	Ghidra xrefs from Camera constructor vtables 0x113C668/0x113C664 identified exact 18B function at 0x009312D0; explain_mismatch exact


### PR DESCRIPTION
## Contribution

- Match `CameraClass::~CameraClass` at the exact Ghidra-recovered function boundary `0x009312D0`.
- Identify the function through Ghidra cross-references to the two Camera vtables written by both constructors.
- Preserve the structural investigation in `reverse/re_attempts.log`.

## Verification

- `python3 tools/check_csv.py` — OK (`functions.csv` 10,185 rows; `symbols.csv` 3,265 rows)
- `./build.sh Code/Libraries/Source/WWVegas/WW3D2/camera.cpp` — OK (`51/51` functions matched; string refs OK)
- Normal pre-commit hook — OK (ledger integrity and changed source byte-verified)

This PR contains one commit and one individual matched-function contribution.
