### PR TITLE
Match three INI scalar parsers

### DIFF
--- a/Code/masm_dumps/parseAngleReal_INI_SAXPAV1_PAX1PBX_Z_852D30.asm
+++ b/Code/masm_dumps/parseAngleReal_INI_SAXPAV1_PAX1PBX_Z_852D30.asm
@@ -1,0 +1,17 @@
+.386
+.model flat
+
+; ?parseAngleReal@INI@@SAXPAV1@PAX1PBX@Z
+; Retail @ 00C52D30 size 92
+_TEXT SEGMENT
+public ?parseAngleReal@INI@@SAXPAV1@PAX1PBX@Z
+?parseAngleReal@INI@@SAXPAV1@PAX1PBX@Z PROC
+    db 8bh, 44h, 24h, 04h, 83h, 0ech, 08h, 56h, 8bh, 0b0h, 14h, 04h, 00h, 00h, 56h, 6ah
+    db 00h, 0ffh, 15h, 0d8h, 94h, 35h, 01h, 83h, 0c4h, 08h, 85h, 0c0h, 75h, 24h, 56h, 68h
+    db 50h, 03h, 13h, 01h, 8dh, 4ch, 24h, 0ch, 6ah, 03h, 51h, 0e8h, 0a0h, 0d8h, 0ffh, 0ffh
+    db 83h, 0c4h, 10h, 68h, 30h, 0fch, 1dh, 01h, 8dh, 54h, 24h, 08h, 52h, 0e8h, 8eh, 3fh
+    db 1ah, 00h, 50h, 0e8h, 68h, 0f9h, 0ffh, 0ffh, 0d8h, 0dh, 54h, 59h, 07h, 01h, 8bh, 44h
+    db 24h, 1ch, 83h, 0c4h, 04h, 0d9h, 18h, 5eh, 83h, 0c4h, 08h, 0c3h
+?parseAngleReal@INI@@SAXPAV1@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/Code/masm_dumps/parseBitInInt32_INI_SAXPAV1_PAX1PBX_Z_852E60.asm
+++ b/Code/masm_dumps/parseBitInInt32_INI_SAXPAV1_PAX1PBX_Z_852E60.asm
@@ -1,0 +1,19 @@
+.386
+.model flat
+
+; ?parseBitInInt32@INI@@SAXPAV1@PAX1PBX@Z
+; Retail @ 00C52E60 size 115
+_TEXT SEGMENT
+public ?parseBitInInt32@INI@@SAXPAV1@PAX1PBX@Z
+?parseBitInInt32@INI@@SAXPAV1@PAX1PBX@Z PROC
+    db 8bh, 44h, 24h, 04h, 83h, 0ech, 08h, 56h, 8bh, 0b0h, 14h, 04h, 00h, 00h, 56h, 6ah
+    db 00h, 0ffh, 15h, 0d8h, 94h, 35h, 01h, 83h, 0c4h, 08h, 85h, 0c0h, 75h, 24h, 56h, 68h
+    db 50h, 03h, 13h, 01h, 8dh, 4ch, 24h, 0ch, 6ah, 03h, 51h, 0e8h, 70h, 0d7h, 0ffh, 0ffh
+    db 83h, 0c4h, 10h, 68h, 30h, 0fch, 1dh, 01h, 8dh, 54h, 24h, 08h, 52h, 0e8h, 5eh, 3eh
+    db 1ah, 00h, 50h, 0e8h, 0a8h, 0f6h, 0ffh, 0ffh, 83h, 0c4h, 04h, 84h, 0c0h, 8bh, 44h, 24h
+    db 18h, 74h, 0fh, 8bh, 10h, 8bh, 4ch, 24h, 1ch, 0bh, 0d1h, 89h, 10h, 5eh, 83h, 0c4h
+    db 08h, 0c3h, 8bh, 54h, 24h, 1ch, 8bh, 08h, 0f7h, 0d2h, 23h, 0cah, 89h, 08h, 5eh, 83h
+    db 0c4h, 08h, 0c3h
+?parseBitInInt32@INI@@SAXPAV1@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/Code/masm_dumps/parsePositiveNonZeroReal_INI_SAXPAV1_PAX1PBX_Z_852B80.asm
+++ b/Code/masm_dumps/parsePositiveNonZeroReal_INI_SAXPAV1_PAX1PBX_Z_852B80.asm
@@ -1,0 +1,20 @@
+.386
+.model flat
+
+; ?parsePositiveNonZeroReal@INI@@SAXPAV1@PAX1PBX@Z
+; Retail @ 00C52B80 size 144
+_TEXT SEGMENT
+public ?parsePositiveNonZeroReal@INI@@SAXPAV1@PAX1PBX@Z
+?parsePositiveNonZeroReal@INI@@SAXPAV1@PAX1PBX@Z PROC
+    db 8bh, 44h, 24h, 04h, 83h, 0ech, 08h, 56h, 8bh, 0b0h, 14h, 04h, 00h, 00h, 56h, 6ah
+    db 00h, 0ffh, 15h, 0d8h, 94h, 35h, 01h, 83h, 0c4h, 08h, 85h, 0c0h, 75h, 24h, 56h, 68h
+    db 50h, 03h, 13h, 01h, 8dh, 4ch, 24h, 0ch, 6ah, 03h, 51h, 0e8h, 50h, 0dah, 0ffh, 0ffh
+    db 83h, 0c4h, 10h, 68h, 30h, 0fch, 1dh, 01h, 8dh, 54h, 24h, 08h, 52h, 0e8h, 3eh, 41h
+    db 1ah, 00h, 50h, 0e8h, 18h, 0fbh, 0ffh, 0ffh, 0d9h, 0c0h, 8bh, 44h, 24h, 1ch, 0d9h, 18h
+    db 83h, 0c4h, 04h, 0d8h, 15h, 50h, 53h, 07h, 01h, 0dfh, 0e0h, 0f6h, 0c4h, 41h, 7ah, 29h
+    db 83h, 0ech, 08h, 0ddh, 1ch, 24h, 68h, 0f4h, 07h, 13h, 01h, 8dh, 4ch, 24h, 10h, 6ah
+    db 03h, 51h, 0e8h, 09h, 0dah, 0ffh, 0ffh, 83h, 0c4h, 14h, 68h, 30h, 0fch, 1dh, 01h, 8dh
+    db 54h, 24h, 08h, 52h, 0e8h, 0f7h, 40h, 1ah, 00h, 0ddh, 0d8h, 5eh, 83h, 0c4h, 08h, 0c3h
+?parsePositiveNonZeroReal@INI@@SAXPAV1@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10315,3 +10315,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?parseICoord2D@INI@@SAXPAV1@PAX1PBX@Z,,0x00853420,60,Code/masm_dumps/parseICoord2D_INI_SAXPAV1_PAX1PBX_Z_853420.asm,matched,Ghidra-bounded gap with X Y sub-token flow verified scanInt calls and two integer stores
 ?parsePositiveNonZeroReal@INI@@SAXPAV1@PAX1PBX@Z,,0x00852B80,144,Code/masm_dumps/parsePositiveNonZeroReal_INI_SAXPAV1_PAX1PBX_Z_852B80.asm,matched,Ghidra bounded retail body; scanReal call and exact expected > 0 diagnostic
 ?parseAngleReal@INI@@SAXPAV1@PAX1PBX@Z,,0x00852D30,92,Code/masm_dumps/parseAngleReal_INI_SAXPAV1_PAX1PBX_Z_852D30.asm,matched,Ghidra bounded retail body; scanReal call and PI/180 degree-to-radian constant
+?parseBitInInt32@INI@@SAXPAV1@PAX1PBX@Z,,0x00852E60,115,Code/masm_dumps/parseBitInInt32_INI_SAXPAV1_PAX1PBX_Z_852E60.asm,matched,Ghidra bounded retail body; scanBool call with OR or AND-not mask update

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10314,3 +10314,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?parseCoord2D@INI@@SAXPAV1@PAX1PBX@Z,,0x008533E0,60,Code/masm_dumps/parseCoord2D_INI_SAXPAV1_PAX1PBX_Z_8533E0.asm,matched,Ghidra X Y sub-token flow with verified scanReal calls and two float stores
 ?parseICoord2D@INI@@SAXPAV1@PAX1PBX@Z,,0x00853420,60,Code/masm_dumps/parseICoord2D_INI_SAXPAV1_PAX1PBX_Z_853420.asm,matched,Ghidra-bounded gap with X Y sub-token flow verified scanInt calls and two integer stores
 ?parsePositiveNonZeroReal@INI@@SAXPAV1@PAX1PBX@Z,,0x00852B80,144,Code/masm_dumps/parsePositiveNonZeroReal_INI_SAXPAV1_PAX1PBX_Z_852B80.asm,matched,Ghidra bounded retail body; scanReal call and exact expected > 0 diagnostic
+?parseAngleReal@INI@@SAXPAV1@PAX1PBX@Z,,0x00852D30,92,Code/masm_dumps/parseAngleReal_INI_SAXPAV1_PAX1PBX_Z_852D30.asm,matched,Ghidra bounded retail body; scanReal call and PI/180 degree-to-radian constant

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10313,3 +10313,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?parseCoord3D@INI@@SAXPAV1@PAX1PBX@Z,,0x00853380,84,Code/masm_dumps/parseCoord3D_INI_SAXPAV1_PAX1PBX_Z_853380.asm,matched,Ghidra X Y Z sub-token flow with verified scanReal calls and three float stores
 ?parseCoord2D@INI@@SAXPAV1@PAX1PBX@Z,,0x008533E0,60,Code/masm_dumps/parseCoord2D_INI_SAXPAV1_PAX1PBX_Z_8533E0.asm,matched,Ghidra X Y sub-token flow with verified scanReal calls and two float stores
 ?parseICoord2D@INI@@SAXPAV1@PAX1PBX@Z,,0x00853420,60,Code/masm_dumps/parseICoord2D_INI_SAXPAV1_PAX1PBX_Z_853420.asm,matched,Ghidra-bounded gap with X Y sub-token flow verified scanInt calls and two integer stores
+?parsePositiveNonZeroReal@INI@@SAXPAV1@PAX1PBX@Z,,0x00852B80,144,Code/masm_dumps/parsePositiveNonZeroReal_INI_SAXPAV1_PAX1PBX_Z_852B80.asm,matched,Ghidra bounded retail body; scanReal call and exact expected > 0 diagnostic


### PR DESCRIPTION
## What changed

- matched `INI::parsePositiveNonZeroReal` from its Ghidra-bounded retail body and exact validation diagnostic
- matched `INI::parseAngleReal` from its retail degree-to-radian conversion
- matched `INI::parseBitInInt32` from its retail boolean mask control flow
- preserved one contribution per commit

## Why

These are three independently verified INI parser functions that advance the matched-function ledger without speculative identities.

## Verification

```text
Full verification
Baseline: OK 2 file(s) (bfme1.workshop-vanilla-1.03)
Incremental compile: 0 of 1696 source(s)
Functions: OK 10317/10317 matched across 1696 source file(s)
String-ref verify: OK (954 literals + 46 empty-string refs verified, 0 unverified/skipped)
DIR32 consistency: OK (3349 symbols; 89 whitelisted, 0 new)
Source claims: OK (0 sources, 4 whitelisted unclaimed)
No-op patch: OK build/patch/lotrbfme.noop.exe
```
