### PR TITLE
Match three INI integer-width parsers

### DIFF
--- a/Code/masm_dumps/parseShort_INI_SAXPAV1_PAX1PBX_Z_852960.asm
+++ b/Code/masm_dumps/parseShort_INI_SAXPAV1_PAX1PBX_Z_852960.asm
@@ -1,0 +1,19 @@
+.386
+.model flat
+
+; ?parseShort@INI@@SAXPAV1@PAX1PBX@Z
+; Retail @ 00C52960 size 124
+_TEXT SEGMENT
+public ?parseShort@INI@@SAXPAV1@PAX1PBX@Z
+?parseShort@INI@@SAXPAV1@PAX1PBX@Z PROC
+    db 8bh, 44h, 24h, 04h, 83h, 0ech, 08h, 56h, 8bh, 0b0h, 14h, 04h, 00h, 00h, 56h, 6ah
+    db 00h, 0ffh, 15h, 0d8h, 94h, 35h, 01h, 83h, 0c4h, 08h, 85h, 0c0h, 75h, 24h, 56h, 68h
+    db 50h, 03h, 13h, 01h, 8dh, 4ch, 24h, 0ch, 6ah, 03h, 51h, 0e8h, 70h, 0dch, 0ffh, 0ffh
+    db 83h, 0c4h, 10h, 68h, 30h, 0fch, 1dh, 01h, 8dh, 54h, 24h, 08h, 52h, 0e8h, 5eh, 43h
+    db 1ah, 00h, 50h, 0e8h, 78h, 0fch, 0ffh, 0ffh, 83h, 0c4h, 04h, 3dh, 00h, 80h, 0ffh, 0ffh
+    db 7ch, 13h, 3dh, 0ffh, 7fh, 00h, 00h, 7fh, 0ch, 8bh, 4ch, 24h, 18h, 66h, 89h, 01h
+    db 5eh, 83h, 0c4h, 08h, 0c3h, 68h, 0c0h, 54h, 24h, 01h, 8dh, 54h, 24h, 08h, 52h, 0c7h
+    db 44h, 24h, 0ch, 01h, 00h, 00h, 00h, 0e8h, 24h, 43h, 1ah, 00h
+?parseShort@INI@@SAXPAV1@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/Code/masm_dumps/parseUnsignedByte_INI_SAXPAV1_PAX1PBX_Z_8528E0.asm
+++ b/Code/masm_dumps/parseUnsignedByte_INI_SAXPAV1_PAX1PBX_Z_8528E0.asm
@@ -1,0 +1,19 @@
+.386
+.model flat
+
+; ?parseUnsignedByte@INI@@SAXPAV1@PAX1PBX@Z
+; Retail @ 00C528E0 size 120
+_TEXT SEGMENT
+public ?parseUnsignedByte@INI@@SAXPAV1@PAX1PBX@Z
+?parseUnsignedByte@INI@@SAXPAV1@PAX1PBX@Z PROC
+    db 8bh, 44h, 24h, 04h, 83h, 0ech, 08h, 56h, 8bh, 0b0h, 14h, 04h, 00h, 00h, 56h, 6ah
+    db 00h, 0ffh, 15h, 0d8h, 94h, 35h, 01h, 83h, 0c4h, 08h, 85h, 0c0h, 75h, 24h, 56h, 68h
+    db 50h, 03h, 13h, 01h, 8dh, 4ch, 24h, 0ch, 6ah, 03h, 51h, 0e8h, 0f0h, 0dch, 0ffh, 0ffh
+    db 83h, 0c4h, 10h, 68h, 30h, 0fch, 1dh, 01h, 8dh, 54h, 24h, 08h, 52h, 0e8h, 0deh, 43h
+    db 1ah, 00h, 50h, 0e8h, 0f8h, 0fch, 0ffh, 0ffh, 83h, 0c4h, 04h, 85h, 0c0h, 7ch, 12h, 3dh
+    db 0ffh, 00h, 00h, 00h, 7fh, 0bh, 8bh, 4ch, 24h, 18h, 88h, 01h, 5eh, 83h, 0c4h, 08h
+    db 0c3h, 68h, 0c0h, 54h, 24h, 01h, 8dh, 54h, 24h, 08h, 52h, 0c7h, 44h, 24h, 0ch, 01h
+    db 00h, 00h, 00h, 0e8h, 0a8h, 43h, 1ah, 00h
+?parseUnsignedByte@INI@@SAXPAV1@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/Code/masm_dumps/parseUnsignedShort_INI_SAXPAV1_PAX1PBX_Z_8529E0.asm
+++ b/Code/masm_dumps/parseUnsignedShort_INI_SAXPAV1_PAX1PBX_Z_8529E0.asm
@@ -1,0 +1,19 @@
+.386
+.model flat
+
+; ?parseUnsignedShort@INI@@SAXPAV1@PAX1PBX@Z
+; Retail @ 00C529E0 size 121
+_TEXT SEGMENT
+public ?parseUnsignedShort@INI@@SAXPAV1@PAX1PBX@Z
+?parseUnsignedShort@INI@@SAXPAV1@PAX1PBX@Z PROC
+    db 8bh, 44h, 24h, 04h, 83h, 0ech, 08h, 56h, 8bh, 0b0h, 14h, 04h, 00h, 00h, 56h, 6ah
+    db 00h, 0ffh, 15h, 0d8h, 94h, 35h, 01h, 83h, 0c4h, 08h, 85h, 0c0h, 75h, 24h, 56h, 68h
+    db 50h, 03h, 13h, 01h, 8dh, 4ch, 24h, 0ch, 6ah, 03h, 51h, 0e8h, 0f0h, 0dbh, 0ffh, 0ffh
+    db 83h, 0c4h, 10h, 68h, 30h, 0fch, 1dh, 01h, 8dh, 54h, 24h, 08h, 52h, 0e8h, 0deh, 42h
+    db 1ah, 00h, 50h, 0e8h, 0f8h, 0fbh, 0ffh, 0ffh, 83h, 0c4h, 04h, 85h, 0c0h, 7ch, 13h, 3dh
+    db 0ffh, 0ffh, 00h, 00h, 7fh, 0ch, 8bh, 4ch, 24h, 18h, 66h, 89h, 01h, 5eh, 83h, 0c4h
+    db 08h, 0c3h, 68h, 0c0h, 54h, 24h, 01h, 8dh, 54h, 24h, 08h, 52h, 0c7h, 44h, 24h, 0ch
+    db 01h, 00h, 00h, 00h, 0e8h, 0a7h, 42h, 1ah, 00h
+?parseUnsignedShort@INI@@SAXPAV1@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10316,3 +10316,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?parsePositiveNonZeroReal@INI@@SAXPAV1@PAX1PBX@Z,,0x00852B80,144,Code/masm_dumps/parsePositiveNonZeroReal_INI_SAXPAV1_PAX1PBX_Z_852B80.asm,matched,Ghidra bounded retail body; scanReal call and exact expected > 0 diagnostic
 ?parseAngleReal@INI@@SAXPAV1@PAX1PBX@Z,,0x00852D30,92,Code/masm_dumps/parseAngleReal_INI_SAXPAV1_PAX1PBX_Z_852D30.asm,matched,Ghidra bounded retail body; scanReal call and PI/180 degree-to-radian constant
 ?parseBitInInt32@INI@@SAXPAV1@PAX1PBX@Z,,0x00852E60,115,Code/masm_dumps/parseBitInInt32_INI_SAXPAV1_PAX1PBX_Z_852E60.asm,matched,Ghidra bounded retail body; scanBool call with OR or AND-not mask update
+?parseUnsignedByte@INI@@SAXPAV1@PAX1PBX@Z,,0x008528E0,120,Code/masm_dumps/parseUnsignedByte_INI_SAXPAV1_PAX1PBX_Z_8528E0.asm,matched,Ghidra neighborhood and CC-bounded retail body; scanInt with 0..255 range and byte store

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10317,3 +10317,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?parseAngleReal@INI@@SAXPAV1@PAX1PBX@Z,,0x00852D30,92,Code/masm_dumps/parseAngleReal_INI_SAXPAV1_PAX1PBX_Z_852D30.asm,matched,Ghidra bounded retail body; scanReal call and PI/180 degree-to-radian constant
 ?parseBitInInt32@INI@@SAXPAV1@PAX1PBX@Z,,0x00852E60,115,Code/masm_dumps/parseBitInInt32_INI_SAXPAV1_PAX1PBX_Z_852E60.asm,matched,Ghidra bounded retail body; scanBool call with OR or AND-not mask update
 ?parseUnsignedByte@INI@@SAXPAV1@PAX1PBX@Z,,0x008528E0,120,Code/masm_dumps/parseUnsignedByte_INI_SAXPAV1_PAX1PBX_Z_8528E0.asm,matched,Ghidra neighborhood and CC-bounded retail body; scanInt with 0..255 range and byte store
+?parseShort@INI@@SAXPAV1@PAX1PBX@Z,,0x00852960,124,Code/masm_dumps/parseShort_INI_SAXPAV1_PAX1PBX_Z_852960.asm,matched,Ghidra neighborhood and CC-bounded retail body; scanInt with signed 16-bit range and word store

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10318,3 +10318,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?parseBitInInt32@INI@@SAXPAV1@PAX1PBX@Z,,0x00852E60,115,Code/masm_dumps/parseBitInInt32_INI_SAXPAV1_PAX1PBX_Z_852E60.asm,matched,Ghidra bounded retail body; scanBool call with OR or AND-not mask update
 ?parseUnsignedByte@INI@@SAXPAV1@PAX1PBX@Z,,0x008528E0,120,Code/masm_dumps/parseUnsignedByte_INI_SAXPAV1_PAX1PBX_Z_8528E0.asm,matched,Ghidra neighborhood and CC-bounded retail body; scanInt with 0..255 range and byte store
 ?parseShort@INI@@SAXPAV1@PAX1PBX@Z,,0x00852960,124,Code/masm_dumps/parseShort_INI_SAXPAV1_PAX1PBX_Z_852960.asm,matched,Ghidra neighborhood and CC-bounded retail body; scanInt with signed 16-bit range and word store
+?parseUnsignedShort@INI@@SAXPAV1@PAX1PBX@Z,,0x008529E0,121,Code/masm_dumps/parseUnsignedShort_INI_SAXPAV1_PAX1PBX_Z_8529E0.asm,matched,Ghidra neighborhood and CC-bounded retail body; scanInt with 0..65535 range and word store


### PR DESCRIPTION
## What changed

- matched `INI::parseUnsignedByte` from its retail `0..255` range check and byte store
- matched `INI::parseShort` from its retail signed 16-bit range check and word store
- matched `INI::parseUnsignedShort` from its retail `0..65535` range check and word store
- preserved one contribution per commit

## Why

Ghidra's surrounding inventory and the retail `CC` boundaries expose these exception-terminated parser bodies even though their starts were not recovered automatically. Their calls, range checks, and store widths uniquely identify them.

## Verification

```text
Full verification
Baseline: OK 2 file(s) (bfme1.workshop-vanilla-1.03)
Incremental compile: 0 of 1699 source(s)
Functions: OK 10320/10320 matched across 1699 source file(s)
String-ref verify: OK (954 literals + 46 empty-string refs verified, 0 unverified/skipped)
DIR32 consistency: OK (3349 symbols; 89 whitelisted, 0 new)
Source claims: OK (0 sources, 4 whitelisted unclaimed)
No-op patch: OK build/patch/lotrbfme.noop.exe
```
