### PR TITLE
Match three INI template-reference parsers

### DIFF
--- a/Code/masm_dumps/parseArmorTemplate_INI_SAXPAV1_PAX1PBX_Z_3EF6D.asm
+++ b/Code/masm_dumps/parseArmorTemplate_INI_SAXPAV1_PAX1PBX_Z_3EF6D.asm
@@ -1,0 +1,12 @@
+.386
+.model flat
+
+; ?parseArmorTemplate@INI@@SAXPAV1@PAX1PBX@Z
+; Retail public thunk @ 0043EF6D size 5; canonical body @ 004BAE50
+_TEXT SEGMENT
+public ?parseArmorTemplate@INI@@SAXPAV1@PAX1PBX@Z
+?parseArmorTemplate@INI@@SAXPAV1@PAX1PBX@Z PROC
+    db 0e9h, 0deh, 0beh, 07h, 00h
+?parseArmorTemplate@INI@@SAXPAV1@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/Code/masm_dumps/parseFXList_INI_SAXPAV1_PAX1PBX_Z_4B47.asm
+++ b/Code/masm_dumps/parseFXList_INI_SAXPAV1_PAX1PBX_Z_4B47.asm
@@ -1,0 +1,12 @@
+.386
+.model flat
+
+; ?parseFXList@INI@@SAXPAV1@PAX1PBX@Z
+; Retail public thunk @ 00404B47 size 5; canonical body @ 004B8E80
+_TEXT SEGMENT
+public ?parseFXList@INI@@SAXPAV1@PAX1PBX@Z
+?parseFXList@INI@@SAXPAV1@PAX1PBX@Z PROC
+    db 0e9h, 34h, 43h, 0bh, 00h
+?parseFXList@INI@@SAXPAV1@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/Code/masm_dumps/parseWeaponTemplate_INI_SAXPAV1_PAX1PBX_Z_CBDF.asm
+++ b/Code/masm_dumps/parseWeaponTemplate_INI_SAXPAV1_PAX1PBX_Z_CBDF.asm
@@ -1,0 +1,12 @@
+.386
+.model flat
+
+; ?parseWeaponTemplate@INI@@SAXPAV1@PAX1PBX@Z
+; Retail public thunk @ 0040CBDF size 5; canonical body @ 004BAEC0
+_TEXT SEGMENT
+public ?parseWeaponTemplate@INI@@SAXPAV1@PAX1PBX@Z
+?parseWeaponTemplate@INI@@SAXPAV1@PAX1PBX@Z PROC
+    db 0e9h, 0dch, 0e2h, 0ah, 00h
+?parseWeaponTemplate@INI@@SAXPAV1@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10330,3 +10330,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?parseAndTranslateLabel@INI@@SAXPAV1@PAX1PBX@Z,,0x00032C45,5,Code/masm_dumps/parseAndTranslateLabel_INI_SAXPAV1_PAX1PBX_Z_32C45.asm,matched,Ghidra canonical body; RankName table xref and game-text translation lookup
 ?parseArmorTemplate@INI@@SAXPAV1@PAX1PBX@Z,,0x0003EF6D,5,Code/masm_dumps/parseArmorTemplate_INI_SAXPAV1_PAX1PBX_Z_3EF6D.asm,matched,Retail ArmorTemplateSet table xref; public thunk to None-aware armor-store lookup body
 ?parseWeaponTemplate@INI@@SAXPAV1@PAX1PBX@Z,,0x0000CBDF,5,Code/masm_dumps/parseWeaponTemplate_INI_SAXPAV1_PAX1PBX_Z_CBDF.asm,matched,Retail CollideWeapon table xref; public thunk to weapon-store lookup body
+?parseFXList@INI@@SAXPAV1@PAX1PBX@Z,,0x00004B47,5,Code/masm_dumps/parseFXList_INI_SAXPAV1_PAX1PBX_Z_4B47.asm,matched,Ghidra canonical body; TopplingFX table xref and None-aware FX-list store lookup

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10328,3 +10328,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?parseColorInt@INI@@SAXPAV1@PAX1PBX@Z,,0x008531E0,409,Code/masm_dumps/parseColorInt_INI_SAXPAV1_PAX1PBX_Z_8531E0.asm,matched,Ghidra-bounded gap; RGBA label parsing range checks and packed 32-bit color store
 ?parseMappedImage@INI@@SAXPAV1@PAX1PBX@Z,,0x0000FC3B,5,Code/masm_dumps/parseMappedImage_INI_SAXPAV1_PAX1PBX_Z_FC3B.asm,matched,Ghidra canonical body; QueueButtonImage table xref and mapped-image manager lookup
 ?parseAndTranslateLabel@INI@@SAXPAV1@PAX1PBX@Z,,0x00032C45,5,Code/masm_dumps/parseAndTranslateLabel_INI_SAXPAV1_PAX1PBX_Z_32C45.asm,matched,Ghidra canonical body; RankName table xref and game-text translation lookup
+?parseArmorTemplate@INI@@SAXPAV1@PAX1PBX@Z,,0x0003EF6D,5,Code/masm_dumps/parseArmorTemplate_INI_SAXPAV1_PAX1PBX_Z_3EF6D.asm,matched,Retail ArmorTemplateSet table xref; public thunk to None-aware armor-store lookup body

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10329,3 +10329,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?parseMappedImage@INI@@SAXPAV1@PAX1PBX@Z,,0x0000FC3B,5,Code/masm_dumps/parseMappedImage_INI_SAXPAV1_PAX1PBX_Z_FC3B.asm,matched,Ghidra canonical body; QueueButtonImage table xref and mapped-image manager lookup
 ?parseAndTranslateLabel@INI@@SAXPAV1@PAX1PBX@Z,,0x00032C45,5,Code/masm_dumps/parseAndTranslateLabel_INI_SAXPAV1_PAX1PBX_Z_32C45.asm,matched,Ghidra canonical body; RankName table xref and game-text translation lookup
 ?parseArmorTemplate@INI@@SAXPAV1@PAX1PBX@Z,,0x0003EF6D,5,Code/masm_dumps/parseArmorTemplate_INI_SAXPAV1_PAX1PBX_Z_3EF6D.asm,matched,Retail ArmorTemplateSet table xref; public thunk to None-aware armor-store lookup body
+?parseWeaponTemplate@INI@@SAXPAV1@PAX1PBX@Z,,0x0000CBDF,5,Code/masm_dumps/parseWeaponTemplate_INI_SAXPAV1_PAX1PBX_Z_CBDF.asm,matched,Retail CollideWeapon table xref; public thunk to weapon-store lookup body


### PR DESCRIPTION
## What changed

- matched `INI::parseArmorTemplate` at its public retail thunk
- matched `INI::parseWeaponTemplate` at its public retail thunk
- matched `INI::parseFXList` at its public retail thunk
- preserved one contribution per commit

## Identification evidence

Retail field-table xrefs identify the entry points from `ArmorTemplateSet::Armor`, `CollideWeapon`, and `TopplingFX`. Their canonical bodies confirm the armor-store, weapon-store, and FX-list-store lookup behavior, including the relevant `None` handling.

## Verification

```text
Full verification
Baseline: OK 2 file(s) (bfme1.workshop-vanilla-1.03)
Incremental compile: 0 of 1711 source(s)
Functions: OK 10332/10332 matched across 1711 source file(s)
String-ref verify: OK (954 literals + 46 empty-string refs verified, 0 unverified/skipped)
DIR32 consistency: OK (3349 symbols; 89 whitelisted, 0 new)
Source claims: OK (0 sources, 4 whitelisted unclaimed)
No-op patch: OK build/patch/lotrbfme.noop.exe
```
