### PR TITLE
Match three INI object-reference parsers

### DIFF
--- a/Code/masm_dumps/parseDamageFX_INI_SAXPAV1_PAX1PBX_Z_12026.asm
+++ b/Code/masm_dumps/parseDamageFX_INI_SAXPAV1_PAX1PBX_Z_12026.asm
@@ -1,0 +1,12 @@
+.386
+.model flat
+
+; ?parseDamageFX@INI@@SAXPAV1@PAX1PBX@Z
+; Retail public thunk @ 00412026 size 5; canonical body @ 004BAFD0
+_TEXT SEGMENT
+public ?parseDamageFX@INI@@SAXPAV1@PAX1PBX@Z
+?parseDamageFX@INI@@SAXPAV1@PAX1PBX@Z PROC
+    db 0e9h, 0a5h, 8fh, 0ah, 00h
+?parseDamageFX@INI@@SAXPAV1@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/Code/masm_dumps/parseThingTemplate_INI_SAXPAV1_PAX1PBX_Z_39969.asm
+++ b/Code/masm_dumps/parseThingTemplate_INI_SAXPAV1_PAX1PBX_Z_39969.asm
@@ -1,0 +1,12 @@
+.386
+.model flat
+
+; ?parseThingTemplate@INI@@SAXPAV1@PAX1PBX@Z
+; Retail public thunk @ 00439969 size 5; canonical body @ 004BAD60
+_TEXT SEGMENT
+public ?parseThingTemplate@INI@@SAXPAV1@PAX1PBX@Z
+?parseThingTemplate@INI@@SAXPAV1@PAX1PBX@Z PROC
+    db 0e9h, 0f2h, 13h, 08h, 00h
+?parseThingTemplate@INI@@SAXPAV1@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/Code/masm_dumps/parseUpgradeTemplate_INI_SAXPAV1_PAX1PBX_Z_4A39A.asm
+++ b/Code/masm_dumps/parseUpgradeTemplate_INI_SAXPAV1_PAX1PBX_Z_4A39A.asm
@@ -1,0 +1,12 @@
+.386
+.model flat
+
+; ?parseUpgradeTemplate@INI@@SAXPAV1@PAX1PBX@Z
+; Retail public thunk @ 0044A39A size 5; canonical body @ 004BB040
+_TEXT SEGMENT
+public ?parseUpgradeTemplate@INI@@SAXPAV1@PAX1PBX@Z
+?parseUpgradeTemplate@INI@@SAXPAV1@PAX1PBX@Z PROC
+    db 0e9h, 0a1h, 0ch, 07h, 00h
+?parseUpgradeTemplate@INI@@SAXPAV1@PAX1PBX@Z ENDP
+_TEXT ENDS
+END

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10333,3 +10333,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?parseFXList@INI@@SAXPAV1@PAX1PBX@Z,,0x00004B47,5,Code/masm_dumps/parseFXList_INI_SAXPAV1_PAX1PBX_Z_4B47.asm,matched,Ghidra canonical body; TopplingFX table xref and None-aware FX-list store lookup
 ?parseDamageFX@INI@@SAXPAV1@PAX1PBX@Z,,0x00012026,5,Code/masm_dumps/parseDamageFX_INI_SAXPAV1_PAX1PBX_Z_12026.asm,matched,Retail ArmorTemplateSet DamageFX xref; public thunk to None-aware damage-FX store lookup
 ?parseThingTemplate@INI@@SAXPAV1@PAX1PBX@Z,,0x00039969,5,Code/masm_dumps/parseThingTemplate_INI_SAXPAV1_PAX1PBX_Z_39969.asm,matched,Retail ControlBar Object xref; public thunk to initialized thing-factory lookup body
+?parseUpgradeTemplate@INI@@SAXPAV1@PAX1PBX@Z,,0x0004A39A,5,Code/masm_dumps/parseUpgradeTemplate_INI_SAXPAV1_PAX1PBX_Z_4A39A.asm,matched,Ghidra canonical body; ControlBar Upgrade xref and upgrade-store lookup

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10332,3 +10332,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?parseWeaponTemplate@INI@@SAXPAV1@PAX1PBX@Z,,0x0000CBDF,5,Code/masm_dumps/parseWeaponTemplate_INI_SAXPAV1_PAX1PBX_Z_CBDF.asm,matched,Retail CollideWeapon table xref; public thunk to weapon-store lookup body
 ?parseFXList@INI@@SAXPAV1@PAX1PBX@Z,,0x00004B47,5,Code/masm_dumps/parseFXList_INI_SAXPAV1_PAX1PBX_Z_4B47.asm,matched,Ghidra canonical body; TopplingFX table xref and None-aware FX-list store lookup
 ?parseDamageFX@INI@@SAXPAV1@PAX1PBX@Z,,0x00012026,5,Code/masm_dumps/parseDamageFX_INI_SAXPAV1_PAX1PBX_Z_12026.asm,matched,Retail ArmorTemplateSet DamageFX xref; public thunk to None-aware damage-FX store lookup
+?parseThingTemplate@INI@@SAXPAV1@PAX1PBX@Z,,0x00039969,5,Code/masm_dumps/parseThingTemplate_INI_SAXPAV1_PAX1PBX_Z_39969.asm,matched,Retail ControlBar Object xref; public thunk to initialized thing-factory lookup body

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10331,3 +10331,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?parseArmorTemplate@INI@@SAXPAV1@PAX1PBX@Z,,0x0003EF6D,5,Code/masm_dumps/parseArmorTemplate_INI_SAXPAV1_PAX1PBX_Z_3EF6D.asm,matched,Retail ArmorTemplateSet table xref; public thunk to None-aware armor-store lookup body
 ?parseWeaponTemplate@INI@@SAXPAV1@PAX1PBX@Z,,0x0000CBDF,5,Code/masm_dumps/parseWeaponTemplate_INI_SAXPAV1_PAX1PBX_Z_CBDF.asm,matched,Retail CollideWeapon table xref; public thunk to weapon-store lookup body
 ?parseFXList@INI@@SAXPAV1@PAX1PBX@Z,,0x00004B47,5,Code/masm_dumps/parseFXList_INI_SAXPAV1_PAX1PBX_Z_4B47.asm,matched,Ghidra canonical body; TopplingFX table xref and None-aware FX-list store lookup
+?parseDamageFX@INI@@SAXPAV1@PAX1PBX@Z,,0x00012026,5,Code/masm_dumps/parseDamageFX_INI_SAXPAV1_PAX1PBX_Z_12026.asm,matched,Retail ArmorTemplateSet DamageFX xref; public thunk to None-aware damage-FX store lookup


### PR DESCRIPTION
## What changed

- matched `INI::parseDamageFX` at its public retail thunk
- matched `INI::parseThingTemplate` at its public retail thunk
- matched `INI::parseUpgradeTemplate` at its public retail thunk
- preserved one contribution per commit

## Identification evidence

Retail field-table xrefs identify the entry points from `ArmorTemplateSet::DamageFX` and the adjacent ControlBar `Object` and `Upgrade` entries. Their Ghidra canonical bodies confirm the damage-FX store, initialized thing-factory, and upgrade-store lookup behavior.

## Verification

```text
Full verification
Baseline: OK 2 file(s) (bfme1.workshop-vanilla-1.03)
Incremental compile: 0 of 1714 source(s)
Functions: OK 10335/10335 matched across 1714 source file(s)
String-ref verify: OK (954 literals + 46 empty-string refs verified, 0 unverified/skipped)
DIR32 consistency: OK (3349 symbols; 89 whitelisted, 0 new)
Source claims: OK (0 sources, 4 whitelisted unclaimed)
No-op patch: OK build/patch/lotrbfme.noop.exe
```
