### PR TITLE
Match RenderObjClass name accessor

### DIFF
--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -10359,3 +10359,4 @@ _atanf,,0x0045B6F0,9,Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp,matched,
 ?iniParseObjectFilter@@YAXPAVINI@@PAX1PBX@Z,,0x00039865,5,Code/masm_dumps/iniParseObjectFilter_YAXPAVINI_PAX1PBX_Z_39865.asm,matched,40 retail object-filter field xrefs strings and Ghidra FUN_0079F470 identify parser
 ?parseEvaMessageFromIni@Eva@@SAXPAVINI@@PAX1PBX@Z,,0x00004B65,5,Code/masm_dumps/parseEvaMessageFromIni_Eva_SAXPAVINI_PAX1PBX_Z_4B65.asm,matched,16 retail Eva-field xrefs and canonical token-map body 0x425B80 identify parser
 ?parseFromINI@?$BitFlags@$0CN@@@SAXPAVINI@@PAX1PBX@Z,,0x00029B9A,5,Code/masm_dumps/parseFromINI_BitFlags_0CN_SAXPAVINI_PAX1PBX_Z_29B9A.asm,matched,11 retail object-status field xrefs and Ghidra FUN_00604E70 identify bit-flag parser
+?Get_Name@RenderObjClass@@UBEPBDXZ,,0x006CF2F0,6,Code/Libraries/Source/WWVegas/WW3D2/rendobj.cpp,matched,unique


### PR DESCRIPTION
## Summary
- match `RenderObjClass::Get_Name` at retail RVA `0x006CF2F0`
- identify the body using the local Ghidra string-xref project and confirm the exact six-byte retail boundary
- preserve one individual contribution in the single commit

## Verification
- `./build.sh Code/Libraries/Source/WWVegas/WW3D2/rendobj.cpp`: 35/35 functions matched; 2/2 string refs verified
- full `./build.sh`: 10,361/10,361 functions matched across 1,739 sources
- string refs: 955 literals + 46 empty strings verified; 0 skipped
- DIR32: 3,349 symbols; 89 whitelisted; 0 new
- source claims and no-op patch: OK