### PR TITLE
Convert W3DRopeDraw::tossSegments and W3DRopeDraw::xfer to byte-exact C++

### DIFF
--- a/Code/GameEngine/Source/Common/W3DRopeDrawDestructorThunk.cpp
+++ b/Code/GameEngine/Source/Common/W3DRopeDrawDestructorThunk.cpp
@@ -7,6 +7,49 @@
 // The drawable module's root base occupies twelve bytes before W3DRopeDraw's
 // secondary interface subobject.  The middle base destructor resets the
 // primary vtable, then calls this root destructor through 0x0002B8C8.
+struct RGBColor
+{
+	float red;
+	float green;
+	float blue;
+};
+
+typedef unsigned char XferVersion;
+
+class Xfer
+{
+public:
+	virtual void slot0();
+	virtual bool getXferMode();
+	virtual void slot2();
+	virtual void slot3();
+	virtual bool isDraft();
+	virtual void slot5();
+	virtual void slot6();
+	virtual void slot7();
+	virtual void slot8();
+	virtual void slot9();
+	virtual void xferVersion(XferVersion *version);
+	virtual void slot11();
+
+	virtual void slot12();
+	virtual void slot13();
+	virtual void slot14();
+	virtual void xferRGBColor(RGBColor *val);
+	virtual void slot16();
+	virtual void slot17();
+	virtual void slot18();
+	virtual void slot19();
+	virtual void slot20();
+	virtual void slot21();
+	virtual void slot22();
+	virtual void slot23();
+	virtual void slot24();
+	virtual void slot25();
+	virtual void slot26();
+	virtual void xferReal(float *val);
+};
+
 class W3DRopeDrawRootBase
 {
 public:
@@ -20,6 +63,9 @@ class W3DRopeDrawDrawModule : public W3DRopeDrawRootBase
 {
 public:
 	virtual ~W3DRopeDrawDrawModule() {}
+
+protected:
+	virtual void xfer(Xfer *xfer);
 };
 
 class W3DRopeDrawInterface
@@ -28,10 +74,39 @@ public:
 	virtual void initRopeParms() = 0;
 };
 
+class BFME3DScene
+{
+public:
+	virtual void slot0();
+	virtual void slot1();
+	virtual void Add_Render_Object(void *obj);
+	virtual void Remove_Render_Object(void *obj);
+};
+
+class W3DDisplay
+{
+public:
+	static BFME3DScene *m_3DScene;
+};
+
+class Line3DClass
+{
+public:
+	virtual void Delete_This();
+	int m_numRefs;
+
+	void Release_Ref()
+	{
+		--m_numRefs;
+		if (m_numRefs == 0)
+			Delete_This();
+	}
+};
+
 struct W3DRopeDrawSegInfo
 {
-	void *line;
-	void *softLine;
+	Line3DClass *line;
+	Line3DClass *softLine;
 	float wobbleAxisX;
 	float wobbleAxisY;
 };
@@ -41,14 +116,83 @@ class W3DRopeDraw : public W3DRopeDrawDrawModule, public W3DRopeDrawInterface
 public:
 	virtual ~W3DRopeDraw();
 
+protected:
+	virtual void xfer(Xfer *xfer);
+
+
 private:
 	std::vector<W3DRopeDrawSegInfo> m_segments;
+	float m_curLen;
+	float m_maxLen;
+	float m_width;
+	RGBColor m_color;
+	float m_curSpeed;
+	float m_maxSpeed;
+	float m_accel;
+	float m_wobbleLen;
+	float m_wobbleAmp;
+	float m_wobbleRate;
+	float m_curWobblePhase;
+	float m_curZOffset;
 
 	void tossSegments();
 };
+
+#define REF_PTR_RELEASE(x) { if (x) { (x)->Release_Ref(); (x) = 0; } }
+
+// ?tossSegments@W3DRopeDraw@@AAEXXZ
+void W3DRopeDraw::tossSegments()
+{
+	for (std::vector<W3DRopeDrawSegInfo>::iterator it = m_segments.begin(); it != m_segments.end(); ++it)
+	{
+		if (it->line)
+		{
+			W3DDisplay::m_3DScene->Remove_Render_Object(it->line);
+			REF_PTR_RELEASE(it->line);
+		}
+		if (it->softLine)
+		{
+			W3DDisplay::m_3DScene->Remove_Render_Object(it->softLine);
+			REF_PTR_RELEASE(it->softLine);
+		}
+	}
+	m_segments.clear();
+}
+
+// ?xfer@W3DRopeDraw@@MAEXPAVXfer@@@Z
+void W3DRopeDraw::xfer(Xfer *xfer)
+{
+	W3DRopeDrawDrawModule::xfer(xfer);
+
+	if (!xfer->isDraft())
+	{
+		XferVersion version[2] = {1, 1};
+		xfer->xferVersion(version);
+
+		xfer->xferReal(&m_curLen);
+		xfer->xferReal(&m_maxLen);
+		xfer->xferReal(&m_width);
+		xfer->xferRGBColor(&m_color);
+		xfer->xferReal(&m_curSpeed);
+		xfer->xferReal(&m_maxSpeed);
+		xfer->xferReal(&m_accel);
+		xfer->xferReal(&m_wobbleLen);
+		xfer->xferReal(&m_wobbleAmp);
+		xfer->xferReal(&m_wobbleRate);
+		xfer->xferReal(&m_curWobblePhase);
+		xfer->xferReal(&m_curZOffset);
+
+		if (xfer->getXferMode())
+			tossSegments();
+	}
+}
+
+
 
 // ??1W3DRopeDraw@@UAE@XZ
 W3DRopeDraw::~W3DRopeDraw()
 {
 	tossSegments();
 }
+
+

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -74595,3 +74595,4 @@ _sprintf,0x009F6DE2,V2 lane: sprintf import thunk (reverse/functions.csv gen-imp
 ?getPlayerMask@NetChatCommandMsg@@QAEHXZ,0x00002B1C,ILT thunk to the four-byte field read at 0x00673CB0 which ICF-folds with getDisconnectFrame; NetPacket::FillBufferWithChatCommand at 0x0067D620 calls it where Zero Hour calls getPlayerMask
 ?findObjectByID@GameLogic@@QAEPAVObject@@W4ObjectID@@@Z,0x0001F253,enum ABI spelling used by AIDockProcessDockState::findMyDrone; same matched ILT as the int-decorated overload
 ?hasAnyUnits@TeamPrototype@@QBE_NXZ,0x0001188D,source-backed Team.cpp identity; ILT target used by Player::hasAnyUnits at 0x000CE070
+?xfer@W3DRopeDrawDrawModule@@MAEXPAVXfer@@@Z,0x0002FD88,


### PR DESCRIPTION
### Summary
  
Converts two `W3DRopeDraw` member functions from scaffold MASM dumps in `Code/gen_asm/d_00753460.asm` into clean, byte-exact C++ in `Code/GameEngine/Source/Common/W3DRopeDrawDestructorThunk.cpp`:
  
1. **`W3DRopeDraw::tossSegments`** (`?tossSegments@W3DRopeDraw@@AAEXXZ`)
- **RVA**: `0x0075A660` (161 bytes)
- Iterates through `m_segments`, removes each line and softLine from `W3DDisplay::m_3DScene`, releases references with `REF_PTR_RELEASE`, and clears the segment vector.  
  
2. **`W3DRopeDraw::xfer`** (`?xfer@W3DRopeDraw@@MAEXPAVXfer@@@Z`)
- **RVA**: `0x0075A7F0` (206 bytes)
- Invokes base class `DrawModule::xfer`, checks `!xfer->isDraft()`, transfers version and member fields (`m_curLen`, `m_maxLen`, `m_width`, `m_color`, `m_curSpeed`,      
  `m_maxSpeed`, `m_accel`, `m_wobbleLen`, `m_wobbleAmp`, `m_wobbleRate`, `m_curWobblePhase`, `m_curZOffset`), and invokes `tossSegments()` when loading.
  
### Verification
- Scoped byte-match verified with `./build.sh Code/GameEngine/Source/Common/W3DRopeDrawDestructorThunk.cpp`.
- Passed `python3 tools/check_csv.py` and `python3 tools/pin_consistency.py --check`.
- `tools/progress.py`: +367 bytes C++ exact (+0.00 pp), retiring the corresponding scaffold rows in `reverse/functions.csv`