### PR TITLE
Convert Object trigger, status, and power helpers

### DIFF
--- a/Code/GameEngine/Source/GameLogic/Object/ObjectFields.cpp
+++ b/Code/GameEngine/Source/GameLogic/Object/ObjectFields.cpp
@@ -335,13 +335,34 @@ __declspec(naked) Real Locomotor::getRudderCorrectionDegree( void ) const
 	}
 }
 
+enum KindOfType
+{
+	KINDOF_INERT = 24
+};
+
+struct KindOfMaskType
+{
+	UnsignedInt m_words[1];
+
+	UnsignedInt getword( size_t pos ) const { return m_words[pos / 32]; }
+	static UnsignedInt maskbit( size_t pos ) { return 1UL << (pos % 32); }
+
+	Bool test( size_t pos ) const
+	{
+		return (getword(pos) & maskbit(pos)) != 0;
+	}
+};
+
 //-------------------------------------------------------------------------------------------------
-/// ThingTemplate stand-in: an Overridable with a flag word at +0xd4.
+/// ThingTemplate stand-in: an Overridable with KindOfMaskType at +0xd0.
 class ThingTemplate : public Overridable
 {
 public:
-	UnsignedByte	_bfme_tt_pad[0xcc];
-	UnsignedInt		_bfme_tt_flags;										///< +0xd4, bit 0x1000 gates the upgrade broadcast
+	Bool isKindOf( KindOfType t ) const { return m_kindof.test(t); }
+
+	UnsignedByte		_bfme_tt_pad[0xc8];
+	KindOfMaskType	m_kindof;														///< +0xd0, bit 24 = KINDOF_INERT
+	UnsignedInt			_bfme_tt_flags;											///< +0xd4, bit 0x1000 gates the upgrade broadcast
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -552,3 +573,103 @@ SpecialPowerUpdateInterface* Object::findSpecialPowerWithOverridableDestinationA
 	}
 	return NULL;
 }
+
+//-------------------------------------------------------------------------------------------------
+class GameLogic
+{
+public:
+	UnsignedInt getFrame( void ) const { return m_frame; }
+
+	UnsignedByte	_bfme_gl_pad[0x3c];
+	UnsignedInt		m_frame;
+};
+
+extern GameLogic* TheGameLogic;
+
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+// ?isKindOf@Thing@@QBE_NW4KindOfType@@@Z
+Bool Thing::isKindOf( KindOfType k ) const
+{
+	const Overridable* tmpl = *(const Overridable* const*)((const char*)this + 4);
+	if (tmpl != NULL)
+		tmpl = tmpl->getFinalOverride();
+	return ((const ThingTemplate*)tmpl)->isKindOf(k);
+}
+
+//-------------------------------------------------------------------------------------------------
+// ?didEnterOrExit@Object@@IBE_NXZ
+Bool Object::didEnterOrExit( void ) const
+{
+	if (isKindOf(KINDOF_INERT))
+		return FALSE;
+
+	UnsignedInt now = TheGameLogic->getFrame();
+	return (m_enteredOrExitedFrame == now || m_enteredOrExitedFrame == now - 1);
+}
+
+//-------------------------------------------------------------------------------------------------
+// ?didEnter@Object@@QBE_NPBVPolygonTrigger@@@Z
+Bool Object::didEnter( const PolygonTrigger *pTrigger ) const
+{
+	if (!didEnterOrExit())
+		return false;
+
+	for (Int i = 0; i < m_numTriggerAreasActive; ++i)
+	{
+		if (m_triggerInfo[i].entered && m_triggerInfo[i].pTrigger == pTrigger)
+			return true;
+	}
+	return false;
+}
+
+//-------------------------------------------------------------------------------------------------
+// ?didExit@Object@@QBE_NPBVPolygonTrigger@@@Z
+Bool Object::didExit( const PolygonTrigger *pTrigger ) const
+{
+	if (!didEnterOrExit())
+		return false;
+
+	for (Int i = 0; i < m_numTriggerAreasActive; ++i)
+	{
+		if (m_triggerInfo[i].exited && m_triggerInfo[i].pTrigger == pTrigger)
+			return true;
+	}
+	return false;
+}
+
+//-------------------------------------------------------------------------------------------------
+// ?testStatus@Object@@QBE_NW4ObjectStatusTypes@@@Z
+Bool Object::testStatus( ObjectStatusTypes s ) const
+{
+	if( m_status.test( s ) )
+		return TRUE;
+
+	const Overridable* tmpl = m_template;
+	if( tmpl != NULL )
+		tmpl = tmpl->getFinalOverride();
+
+	const Object* obj = this;
+	if( (((const ThingTemplate*)tmpl)->_bfme_tt_flags & 0x1000) == 0 )
+	{
+		obj = m_containedBy;
+		if( obj == NULL || !obj->isKindOf( (KindOfType)0x6c ) )
+			return FALSE;
+	}
+
+	if( obj != NULL )
+	{
+		return obj->m_status.test( s );
+	}
+
+	return FALSE;
+}
+
+//-------------------------------------------------------------------------------------------------
+// ?hasSpecialPower@Object@@QBE_NW4SpecialPowerType@@@Z
+Bool Object::hasSpecialPower( SpecialPowerType type ) const
+{
+	return m_specialPowerBits.test( type );
+}
+
+

--- a/reference/shims/bfmeobject/GameLogic/Object.h
+++ b/reference/shims/bfmeobject/GameLogic/Object.h
@@ -101,8 +101,58 @@ enum ObjectScriptStatusBit
 	OBJECT_STATUS_SCRIPT_UNPOWERED	= 0x02
 };
 
+class PolygonTrigger;
+enum KindOfType;
+
+struct TriggerInfo
+{
+	const PolygonTrigger*	pTrigger;										///< +0x00
+	Bool									entered;										///< +0x04
+	Bool									exited;											///< +0x05
+	Bool									isInside;										///< +0x06
+	UnsignedByte					_bfme_pad;									///< +0x07
+};
+
+class Thing
+{
+public:
+	Bool isKindOf( KindOfType k ) const;
+};
+
+enum ObjectStatusTypes
+{
+	OBJECT_STATUS_NONE = 0
+};
+
+struct ObjectStatusMaskType
+{
+	enum { NUM_WORDS = 6 };
+	UnsignedInt m_words[NUM_WORDS];
+
+	Bool test( ObjectStatusTypes s ) const
+	{
+		return (m_words[(UnsignedInt)s >> 5] & (1UL << ((UnsignedInt)s & 31))) != 0;
+	}
+};
+
+enum SpecialPowerType
+{
+	SPECIAL_POWER_INVALID = -1
+};
+
+struct SpecialPowerMaskType
+{
+	enum { NUM_WORDS = 6 };
+	UnsignedInt m_words[NUM_WORDS];
+
+	Bool test( SpecialPowerType s ) const
+	{
+		return (m_words[(UnsignedInt)s >> 5] & (1UL << ((UnsignedInt)s & 31))) != 0;
+	}
+};
+
 // ---------------------------------------------------
-class Object
+class Object : public Thing
 {
 public:
 
@@ -128,24 +178,43 @@ public:
 	void removeUpgrade( const UpgradeTemplate *upgradeT );
 	void updateUpgradeModules( void );
 
+	Bool didEnter( const PolygonTrigger *pTrigger ) const;
+	Bool didExit( const PolygonTrigger *pTrigger ) const;
+	Bool testStatus( ObjectStatusTypes s ) const;
+	Bool hasSpecialPower( SpecialPowerType type ) const;
+
+protected:
+
+	Bool didEnterOrExit( void ) const;
+
 private:
 
 	enum { FOREVER = 0x3fffffff };
 
 	UnsignedByte							_bfme_vtbl[4];
 	const ThingTemplate*			m_template;						///< 0x004 (Thing base)
-	UnsignedByte							_bfme_pad_008[0x1e8];
+	UnsignedByte							_bfme_pad_008[0x108];
+	ObjectStatusMaskType			m_status;							///< 0x110
+	UnsignedByte							_bfme_pad_128[0xc8];
 	BehaviorModule**					m_behaviors;					///< 0x1f0
 	UnsignedByte							_bfme_pad_1f4[8];
 	ContainModuleInterface*		m_contain;						///< 0x1fc
 	UnsignedByte							_bfme_pad_200[4];
 	AIUpdateInterface*				m_ai;									///< 0x204
-	UnsignedByte							_bfme_pad_208[0x1c];
+	UnsignedByte							_bfme_pad_208[0xc];
+	const Object*							m_containedBy;				///< 0x214
+	UnsignedByte							_bfme_pad_218[0xc];
 	UpgradeMaskType						m_objectUpgradesCompleted;	///< 0x224
-	UnsignedByte							_bfme_pad_23c[0x107];
-	UnsignedByte							m_scriptStatus;				///< 0x343
-	UnsignedByte							_bfme_pad_344[0x6c];
-	PartitionData*						m_partitionData;			///< 0x3b0
+	UnsignedByte							_bfme_pad_23c[0x84];
+	SpecialPowerMaskType			m_specialPowerBits;		///< 0x2c0
+	TriggerInfo								m_triggerInfo[5];						///< 0x2d8
+	UnsignedInt								m_enteredOrExitedFrame;			///< 0x300
+	UnsignedByte							_bfme_pad_304[0x3f];
+	UnsignedByte							m_scriptStatus;							///< 0x343
+	UnsignedByte							_bfme_pad_344[2];
+	Char											m_numTriggerAreasActive;		///< 0x346
+	UnsignedByte							_bfme_pad_347[0x69];
+	PartitionData*						m_partitionData;						///< 0x3b0
 
 };  // end class Object
 


### PR DESCRIPTION
Converts 5 naked candidate functions from `Code/gen_asm/d_001c7e60.asm` to byte-exact C++ in `Code/GameEngine/Source/GameLogic/Object/ObjectFields.cpp`, along with corresponding member layout updates in `reference/shims/bfmeobject/GameLogic/Object.h`.                                                                                  
                                                                                                                                                                           
### Converted Functions
    
| RVA | Symbol | Size | Description |
|---|---|---|---|
| `0x001C8BE0` | `Object::didEnterOrExit` | 72 B | Frame window check for trigger area entry/exit, ignoring inert objects |
| `0x001C8C40` | `Object::didEnter` | 120 B | Checks if the object entered the specified polygon trigger area |            
| `0x001C8CE0` | `Object::didExit` | 120 B | Checks if the object exited the specified polygon trigger area |  
| `0x001CC880` | `Object::testStatus` | 126 B | Tests status bitfield at `Object+0x110` with container status propagation |
| `0x001C9BD0` | `Object::hasSpecialPower` | 41 B | Tests special power mask at `Object+0x2c0` |