### PR TITLE
Convert FESL feedback request builder

### DIFF
--- a/Code/GameEngine/Source/GameNetwork/V2FeslFeedbackRequest.cpp
+++ b/Code/GameEngine/Source/GameNetwork/V2FeslFeedbackRequest.cpp
@@ -1,0 +1,65 @@
+// EA FESL client SDK ("jabba") -- feedback transaction request builder.
+// The literal keys and the 'fdbk' category identify the wire payload.  The
+// helper callees serialize an 8-byte-stride target-id array and 0x208-byte
+// chat-log records (64-bit user id followed by a 0x200-byte string).
+
+typedef __int64 FeslInt64;
+
+class Rva007E8810Message
+{
+public:
+	void reset( void );
+	void addString( const char *key, const char *value );
+	void addInt( const char *key, int value );
+	void addInt64( const char *key, FeslInt64 value );
+
+	char m_head[ 0x1C ];
+	unsigned int m_category;
+};
+
+struct Rva007F2010TargetId
+{
+	int id;
+	int unused;
+};
+
+struct Rva007F2080ChatLog
+{
+	FeslInt64 userId;
+	char chat[ 0x200 ];
+};
+
+extern const char * const g_Rva0130A63C;
+
+class Rva007F1F60Feedback
+{
+public:
+	void addTargetIds( Rva007E8810Message *msg,
+		const Rva007F2010TargetId *targetIds, int count );
+	void addChatLog( Rva007E8810Message *msg,
+		const Rva007F2080ChatLog *chatLog, int count );
+	void buildRequest( Rva007E8810Message *msg, int targetType,
+		const Rva007F2010TargetId *targetIds, int targetIdCount,
+		FeslInt64 originatorUserId, const char *message, int feedbackType,
+		const Rva007F2080ChatLog *chatLog, int chatLogCount,
+		const char *extraFeedbackDetail );
+};
+
+void Rva007F1F60Feedback::buildRequest( Rva007E8810Message *msg, int targetType,
+	const Rva007F2010TargetId *targetIds, int targetIdCount,
+	FeslInt64 originatorUserId, const char *message, int feedbackType,
+	const Rva007F2080ChatLog *chatLog, int chatLogCount,
+	const char *extraFeedbackDetail )
+{
+	const char *txn = g_Rva0130A63C;
+	msg->reset();
+	msg->m_category = 'fdbk';
+	msg->addString( "TXN", txn );
+	addTargetIds( msg, targetIds, targetIdCount );
+	msg->addInt( "targetType", targetType );
+	msg->addInt64( "originatorUserId", originatorUserId );
+	msg->addString( "message", message );
+	msg->addInt( "feedbackType", feedbackType );
+	addChatLog( msg, chatLog, chatLogCount );
+	msg->addString( "extraFeedbackDetail", extraFeedbackDetail );
+}

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -11810,6 +11810,7 @@ name,address,notes
 ?addDisconnectPlayerCommand@NetPacket@@IAE_NPAVNetCommandRef@@@Z,0x0067B750,addCommand's jump-table arm for command type 25
 ?addDisconnectScreenOffCommand@NetPacket@@IAE_NPAVNetCommandRef@@@Z,0x00023079,the address addCommand's arm encodes; the body's own incremental-link thunk is a further hop
 ?addDisconnectScreenOffCommand@NetPacket@@IAE_NPAVNetCommandRef@@@Z,0x00679810,addCommand's jump-table arm for command type 28
+?addChatLog@Rva007F1F60Feedback@@QAEXPAVRva007E8810Message@@PBURva007F2080ChatLog@@H@Z,0x007F2080,V2 lane: FESL feedback request chat-log array serializer
 ?addDisconnectVoteCommand@NetPacket@@IAE_NPAVNetCommandRef@@@Z,0x000422F8,the address addCommand's arm encodes; the body's own incremental-link thunk is a further hop
 ?addDisconnectVoteCommand@NetPacket@@IAE_NPAVNetCommandRef@@@Z,0x0067B480,addCommand's jump-table arm for command type 26
 ?addDrawableToLookupTable@GameClient@@QAEXPAVDrawable@@@Z,0x0003CC4A,Open-BFME5 setID retail REL32 pin
@@ -11864,6 +11865,7 @@ name,address,notes
 ?addString@Rva007E8810Message@@QAEXPBD0@Z,0x007E8A10,V2 lane: FESL message append key/value string field
 ?addSupplyCenter@ResourceGatheringManager@@QAEXPAVObject@@@Z,0x0001E23B,Open-BFME5 ILT from zh_sweep packet 002503b0
 ?addSupplyWarehouse@ResourceGatheringManager@@QAEXPAVObject@@@Z,0x00028646,pinned by SupplyWarehouseCreate::onCreate packet 002505a0
+?addTargetIds@Rva007F1F60Feedback@@QAEXPAVRva007E8810Message@@PBURva007F2010TargetId@@H@Z,0x007F2010,V2 lane: FESL feedback request target-id array serializer
 ?addTeam@TeamsInfoRec@@QAEXPBVDict@@@Z,0x0000D828,pinharvest x4 (thunk)
 ?addTeam@TeamsInfoRec@@QAEXPBVDict@@@Z,0x0003275E,pinharvest x2 (thunk)
 ?addTimeOutGameStartMessage@NetPacket@@IAE_NPAVNetCommandRef@@@Z,0x00037263,the address addCommand's arm encodes; the body's own incremental-link thunk is a further hop


### PR DESCRIPTION
## Summary

Reconstructs the 174-byte FESL feedback transaction request builder at `0x007F1F60` as clean, byte-exact C++.

The implementation:

- Builds the `'fdbk'` FESL transaction payload.
- Serializes target IDs and chat-log records through existing retail helpers.
- Emits the verified `targetType`, `originatorUserId`, `message`, `feedbackType`, and `extraFeedbackDetail` fields.
- Repoints the ledger claim from the generated ASM dump to the new C++ source.
- Adds two additive helper pins for the existing array serializers.

## Verification

- Pre-commit hook: passed
- Pre-push hook: passed
- Function verification: `OK 1/1 matched`
- String references: `6 literals verified`
- Pin consistency: passed
- Ledger integrity: passed

## Progress

- Clean C++ exact: `+174 bytes`
- ASM-only exact: `-174 bytes`
- Total exact coverage: unchanged