### PR TITLE
Reconstruct cursor disable helper at 0x0060D3E0

### DIFF
--- a/Code/GameEngine/Source/Common/BfmeLivingWorldManagerIsCampaignVictorious.cpp
+++ b/Code/GameEngine/Source/Common/BfmeLivingWorldManagerIsCampaignVictorious.cpp
@@ -1,0 +1,32 @@
+// cl: /EHs-c-
+//
+// Open-BFME: retail 0x0060D3D0, 9 bytes.
+//
+// The sole caller loads TheLivingWorldManager (0x012F706C) into ecx before
+// calling this method.  The method does not use that receiver: it loads
+// TheCampaignManager (0x012F1028) and returns its byte at +0x2C.  The vendored
+// CampaignManager header identifies that byte as m_victorious, but its Zero
+// Hour layout differs, so the measured BFME slice remains TU-local here.
+
+typedef bool Bool;
+
+class CampaignManager;
+extern CampaignManager *TheCampaignManager;
+
+class BfmeCampaignManagerVictoriousSlice
+{
+public:
+	unsigned char m_unmodelled00[ 0x2C ];
+	Bool m_victorious;
+};
+
+class BfmeLivingWorldManager
+{
+public:
+	Bool isCampaignVictorious( void );
+};
+
+Bool BfmeLivingWorldManager::isCampaignVictorious( void )
+{
+	return ((BfmeCampaignManagerVictoriousSlice *)TheCampaignManager)->m_victorious;
+}

--- a/Code/GameEngine/Source/Common/Rva0060D3E0CursorDisable.cpp
+++ b/Code/GameEngine/Source/Common/Rva0060D3E0CursorDisable.cpp
@@ -1,0 +1,60 @@
+// cl: /EHs-c-
+//
+// Open-BFME: retail 0x0060D3E0, 34 bytes.
+//
+// The body clears the byte at this+0x288, selects cursor 0x28 through
+// TheMouse's BFME-only vtable layout, then passes false to slot 0x40 of the
+// global at 0x012F7048.  Mouse::setCursor is independently established at
+// vtable+0x38 in LanGameOptionsMenu.cpp.  The second receiver's identity is
+// not yet recovered, so its type and method retain address-derived names.
+
+typedef bool Bool;
+
+class Mouse;
+extern Mouse *TheMouse;
+
+class BfmeVirtualCursorMouse0060D3E0
+{
+public:
+	virtual void slot00() = 0; virtual void slot04() = 0;
+	virtual void slot08() = 0; virtual void slot0C() = 0;
+	virtual void slot10() = 0; virtual void slot14() = 0;
+	virtual void slot18() = 0; virtual void slot1C() = 0;
+	virtual void slot20() = 0; virtual void slot24() = 0;
+	virtual void slot28() = 0; virtual void slot2C() = 0;
+	virtual void slot30() = 0; virtual void slot34() = 0;
+	virtual void setCursor( int cursor ) = 0;
+};
+
+class Glo012F7048CursorGate
+{
+public:
+	virtual void slot00() = 0; virtual void slot04() = 0;
+	virtual void slot08() = 0; virtual void slot0C() = 0;
+	virtual void slot10() = 0; virtual void slot14() = 0;
+	virtual void slot18() = 0; virtual void slot1C() = 0;
+	virtual void slot20() = 0; virtual void slot24() = 0;
+	virtual void slot28() = 0; virtual void slot2C() = 0;
+	virtual void slot30() = 0; virtual void slot34() = 0;
+	virtual void slot38() = 0; virtual void slot3C() = 0;
+	virtual void setEnabled( Bool enabled ) = 0;
+};
+
+extern Glo012F7048CursorGate *Glo012F7048;
+
+class Rva0060D3E0CursorDisable
+{
+public:
+	void apply( void );
+
+private:
+	unsigned char m_unmodelled00[ 0x288 ];
+	Bool m_enabled;
+};
+
+void Rva0060D3E0CursorDisable::apply( void )
+{
+	m_enabled = false;
+	((BfmeVirtualCursorMouse0060D3E0 *)TheMouse)->setCursor( 0x28 );
+	Glo012F7048->setEnabled( false );
+}

--- a/Code/GameEngine/Source/Common/Rva0060D480CampaignGate.cpp
+++ b/Code/GameEngine/Source/Common/Rva0060D480CampaignGate.cpp
@@ -1,0 +1,48 @@
+// cl: /EHs-c-
+//
+// Open-BFME: retail 0x0060D480, 46 bytes.
+//
+// The predicate is true only in global mode 1, while this object's byte at
+// +0x288 is clear, and while the CampaignManager-family global at 0x012F1028
+// has its byte at +0x78 clear.  The types are deliberately TU-local measured
+// slices; the remaining owner identity has not been recovered.
+
+typedef bool Bool;
+
+class Glo012F7048CampaignGateMode
+{
+public:
+	void *m_vtable;
+	int m_mode;
+};
+
+extern Glo012F7048CampaignGateMode *Glo012F7048;
+
+class CampaignManager;
+extern CampaignManager *TheCampaignManager;
+
+class BfmeCampaignManagerFlag78Slice
+{
+public:
+	unsigned char m_unmodelled00[ 0x78 ];
+	Bool m_flag78;
+};
+
+class Rva0060D480CampaignGate
+{
+public:
+	Bool isOpen( void ) const;
+
+private:
+	unsigned char m_unmodelled00[ 0x288 ];
+	Bool m_blocked;
+};
+
+Bool Rva0060D480CampaignGate::isOpen( void ) const
+{
+	if ( Glo012F7048->m_mode == 1
+		&& !m_blocked
+		&& !((BfmeCampaignManagerFlag78Slice *)TheCampaignManager)->m_flag78 )
+		return true;
+	return false;
+}


### PR DESCRIPTION
## Summary

- Replace the 34-byte generated dump at `0x0060D3E0` with clean, byte-exact C++.
- Clear the byte at `this+0x288`, select cursor `0x28` through BFME `Mouse::setCursor` at vtable slot `+0x38`, and disable the global at `0x012F7048` through its observed `+0x40` slot.
- Keep address-derived names where the remaining receiver identity is not yet recovered.

## Verification

- `python3 tools/check_csv.py`
- `./build.sh Code/GameEngine/Source/Common/Rva0060D3E0CursorDisable.cpp`
- Pre-commit hook passed.
- Pre-push hook passed.
- `python3 tools/progress.py origin/master`: C++ exact `+34 bytes`; ASM-only exact `-34 bytes`.

Rebased cleanly onto `origin/master` at `c4a0adeb3` with no merge conflicts.