### PR TITLE
Reconstruct 45 DirtySock functions

### DIFF
--- a/Code/Libraries/Source/DirtySock/Y4BoundedCopy.c
+++ b/Code/Libraries/Source/DirtySock/Y4BoundedCopy.c
@@ -1,0 +1,18 @@
+// cl: /Od /MD /DNDEBUG
+
+void Rva0080D930( const char *source, int sourceLength,
+	char *destination, int destinationLength )
+{
+	for ( ; sourceLength > 0 && destinationLength > 1;
+		sourceLength--, destinationLength-- )
+	{
+		*destination = *source;
+		destination++;
+		source++;
+	}
+
+	if ( destinationLength > 0 )
+	{
+		*destination = 0;
+	}
+}

--- a/Code/Libraries/Source/DirtySock/Y4BoundedCopy.c
+++ b/Code/Libraries/Source/DirtySock/Y4BoundedCopy.c
@@ -1,4 +1,4 @@
-// cl: /Od /MD /DNDEBUG
+// cl: /Od /GZ /GS /MD /DNDEBUG
 
 void Rva0080D930( const char *source, int sourceLength,
 	char *destination, int destinationLength )
@@ -15,4 +15,61 @@ void Rva0080D930( const char *source, int sourceLength,
 	{
 		*destination = 0;
 	}
+}
+
+const unsigned char *Rva0080D7A0( const unsigned char *cursor,
+	const unsigned char *end, int *firstByte, int *valueOut )
+{
+	int byteCount;
+	unsigned int value;
+
+	if ( valueOut != 0 )
+	{
+		*valueOut = 0;
+	}
+	if ( firstByte != 0 )
+	{
+		*firstByte = 0;
+	}
+	if ( cursor == 0 )
+	{
+		return 0;
+	}
+	if ( cursor == end )
+	{
+		return 0;
+	}
+
+	if ( firstByte != 0 )
+	{
+		*firstByte = *cursor;
+	}
+	cursor++;
+	if ( cursor == end )
+	{
+		return 0;
+	}
+
+	value = *cursor;
+	cursor++;
+	if ( value > 0x7F )
+	{
+		byteCount = value & 0x7F;
+		value = 0;
+		for ( ; byteCount > 0; byteCount-- )
+		{
+			if ( cursor == end )
+			{
+				return 0;
+			}
+			value = ( value << 8 ) | *cursor;
+			cursor++;
+		}
+	}
+
+	if ( valueOut != 0 )
+	{
+		*valueOut = value;
+	}
+	return cursor;
 }

--- a/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
@@ -59,6 +59,7 @@ struct Rva0080B000Comm
 void *Rva007FD2D0( int family, int type, int protocol );
 void Rva007FD3F0( void *socket );
 int Rva007FD510( void *socket, const void *address, int addressLength );
+int Rva007FD7A0( void *socket, int mode );
 
 int Rva0080B150( struct Rva0080B000Comm *comm, const void *address,
 	int addressLength )
@@ -75,6 +76,11 @@ int Rva0080B150( struct Rva0080B000Comm *comm, const void *address,
 	}
 
 	return Rva007FD510( comm->m_socket, address, addressLength );
+}
+
+int Rva0080B460( struct Rva0080B000Comm *comm, int mode )
+{
+	return Rva007FD7A0( comm->m_socket, mode );
 }
 
 struct Rva00812320Module;

--- a/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
@@ -38,10 +38,17 @@ void *Rva0080B000( void )
 }
 
 void Rva0080ADE0( void *object, int releaseState );
+void Rva007F0030( void *object );
 
 void Rva0080B050( void *object )
 {
 	Rva0080ADE0( object, 0 );
+}
+
+void Rva0080B070( void *object )
+{
+	Rva0080ADE0( object, 0 );
+	Rva007F0030( object );
 }
 
 struct Rva00812320Module;

--- a/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
@@ -51,6 +51,32 @@ void Rva0080B070( void *object )
 	Rva007F0030( object );
 }
 
+struct Rva0080B000Comm
+{
+	void *m_socket;
+};
+
+void *Rva007FD2D0( int family, int type, int protocol );
+void Rva007FD3F0( void *socket );
+int Rva007FD510( void *socket, const void *address, int addressLength );
+
+int Rva0080B150( struct Rva0080B000Comm *comm, const void *address,
+	int addressLength )
+{
+	if ( comm->m_socket != 0 )
+	{
+		Rva007FD3F0( comm->m_socket );
+	}
+
+	comm->m_socket = Rva007FD2D0( 2, 1, 0 );
+	if ( comm->m_socket == 0 )
+	{
+		return -7;
+	}
+
+	return Rva007FD510( comm->m_socket, address, addressLength );
+}
+
 struct Rva00812320Module;
 
 struct Rva00812320Module *Rva00812320( int iEntries );

--- a/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
@@ -37,6 +37,13 @@ void *Rva0080B000( void )
 	return pObject;
 }
 
+void Rva0080ADE0( void *object, int releaseState );
+
+void Rva0080B050( void *object )
+{
+	Rva0080ADE0( object, 0 );
+}
+
 struct Rva00812320Module;
 
 struct Rva00812320Module *Rva00812320( int iEntries );

--- a/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
@@ -14,6 +14,7 @@ void *Rva007F0000( unsigned int size );
 
 void * __cdecl memset( void *dest, int c, unsigned int count );
 void * __cdecl memcpy( void *dest, const void *source, unsigned int count );
+unsigned int __cdecl strlen( const char *text );
 
 /* 0x0080B000 ALLOCATES AND ZEROES A 0x124-BYTE OBJECT.  The size is a literal
  * in two places -- once for the allocation and once for the clear -- so the
@@ -59,7 +60,7 @@ struct Rva0080B000Comm
 	char m_address[ 0x10 ];
 	int m_addressLength;
 	char m_gap11C[ 4 ];
-	int m_releaseState;
+	void *m_backend;
 };
 
 void *Rva007FD2D0( int family, int type, int protocol );
@@ -92,7 +93,7 @@ int Rva0080B460( struct Rva0080B000Comm *comm, int mode )
 
 int Rva0080B480( struct Rva0080B000Comm *comm )
 {
-	Rva0080ADE0( comm, comm->m_releaseState != 0 );
+	Rva0080ADE0( comm, comm->m_backend != 0 );
 	return 0;
 }
 
@@ -124,6 +125,52 @@ struct Rva0080B000Comm *Rva0080B0A0( struct Rva0080B000Comm *comm,
 	memcpy( accepted->m_address, address, *addressLength );
 	accepted->m_addressLength = 0x14;
 	return accepted;
+}
+
+struct Rva0080D980Backend
+{
+	int m_field00;
+	int m_field04;
+};
+
+int Rva0080C390( struct Rva0080B000Comm *comm, const void *data, int length );
+int Rva007FD920( void *socket, const void *data, int length, int flags,
+	const void *address, int addressLength );
+
+int Rva0080D980( struct Rva0080B000Comm *comm, const char *data, int length )
+{
+	int result;
+	struct Rva0080D980Backend *backend;
+
+	result = -1;
+	backend = (struct Rva0080D980Backend *)comm->m_backend;
+	if ( length < 0 )
+	{
+		length = strlen( data );
+	}
+	if ( length > 16000 )
+	{
+		length = 16000;
+	}
+
+	if ( comm->m_addressLength == 0x10 )
+	{
+		result = 0;
+		if ( backend->m_field04 == 0 )
+		{
+			result = Rva0080C390( comm, data, length );
+			if ( result >= 0 )
+			{
+				result = length;
+			}
+		}
+	}
+
+	if ( comm->m_addressLength == 0x14 )
+	{
+		result = Rva007FD920( comm->m_socket, data, length, 0, 0, 0 );
+	}
+	return result;
 }
 
 struct Rva00812320Module;

--- a/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
@@ -13,6 +13,7 @@
 void *Rva007F0000( unsigned int size );
 
 void * __cdecl memset( void *dest, int c, unsigned int count );
+void * __cdecl memcpy( void *dest, const void *source, unsigned int count );
 
 /* 0x0080B000 ALLOCATES AND ZEROES A 0x124-BYTE OBJECT.  The size is a literal
  * in two places -- once for the allocation and once for the clear -- so the
@@ -54,7 +55,10 @@ void Rva0080B070( void *object )
 struct Rva0080B000Comm
 {
 	void *m_socket;
-	char m_gap04[ 0x11C ];
+	char m_gap04[ 0x104 ];
+	char m_address[ 0x10 ];
+	int m_addressLength;
+	char m_gap11C[ 4 ];
 	int m_releaseState;
 };
 
@@ -62,6 +66,7 @@ void *Rva007FD2D0( int family, int type, int protocol );
 void Rva007FD3F0( void *socket );
 int Rva007FD510( void *socket, const void *address, int addressLength );
 int Rva007FD7A0( void *socket, int mode );
+void *Rva007FD7D0( void *socket, void *address, int *addressLength );
 
 int Rva0080B150( struct Rva0080B000Comm *comm, const void *address,
 	int addressLength )
@@ -89,6 +94,36 @@ int Rva0080B480( struct Rva0080B000Comm *comm )
 {
 	Rva0080ADE0( comm, comm->m_releaseState != 0 );
 	return 0;
+}
+
+struct Rva0080B000Comm *Rva0080B0A0( struct Rva0080B000Comm *comm,
+	int unsupported, void *address, int *addressLength )
+{
+	struct Rva0080B000Comm *accepted;
+	void *socket;
+
+	if ( unsupported != 0 )
+	{
+		return 0;
+	}
+
+	socket = Rva007FD7D0( comm->m_socket, address, addressLength );
+	if ( socket == 0 )
+	{
+		return 0;
+	}
+
+	accepted = (struct Rva0080B000Comm *)Rva0080B000();
+	if ( accepted == 0 )
+	{
+		Rva007FD3F0( socket );
+		return 0;
+	}
+
+	accepted->m_socket = socket;
+	memcpy( accepted->m_address, address, *addressLength );
+	accepted->m_addressLength = 0x14;
+	return accepted;
 }
 
 struct Rva00812320Module;

--- a/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommAlloc.c
@@ -54,6 +54,8 @@ void Rva0080B070( void *object )
 struct Rva0080B000Comm
 {
 	void *m_socket;
+	char m_gap04[ 0x11C ];
+	int m_releaseState;
 };
 
 void *Rva007FD2D0( int family, int type, int protocol );
@@ -81,6 +83,12 @@ int Rva0080B150( struct Rva0080B000Comm *comm, const void *address,
 int Rva0080B460( struct Rva0080B000Comm *comm, int mode )
 {
 	return Rva007FD7A0( comm->m_socket, mode );
+}
+
+int Rva0080B480( struct Rva0080B000Comm *comm )
+{
+	Rva0080ADE0( comm, comm->m_releaseState != 0 );
+	return 0;
 }
 
 struct Rva00812320Module;

--- a/Code/Libraries/Source/DirtySock/Y4CommDigest.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommDigest.c
@@ -17,6 +17,15 @@ struct Rva00810060Context
 	unsigned char m_block[ 0x40 ];		/* +0x14 */
 };
 
+void Rva00810020( struct Rva00810060Context *context )
+{
+	context->m_count = 0;
+	context->m_state[ 0 ] = 0x67452301;
+	context->m_state[ 1 ] = 0xEFCDAB89;
+	context->m_state[ 2 ] = 0x98BADCFE;
+	context->m_state[ 3 ] = 0x10325476;
+}
+
 void Rva00810120( struct Rva00810060Context *context );
 
 /* 0x00810060 FEEDS BYTES INTO THE DIGEST, flushing whenever the block fills.

--- a/Code/Libraries/Source/DirtySock/Y4CommRingIdle.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommRingIdle.c
@@ -119,6 +119,17 @@ int Rva00815790( struct Rva00815B50Comm *comm )
 	return 0;
 }
 
+int Rva008157E0( struct Rva00815B50Comm *comm )
+{
+	if ( comm->m_socket != 0 )
+	{
+		Rva007FD3F0( comm->m_socket );
+		Rva008154F0( comm, 0 );
+	}
+	comm->m_state = 0;
+	return 0;
+}
+
 void Rva00815BB0( struct Rva00815B50Comm *comm );
 
 /* The socket callback.  Its first two arguments -- the handle and the event

--- a/Code/Libraries/Source/DirtySock/Y4CommRingIdle.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommRingIdle.c
@@ -30,7 +30,9 @@ void Rva007FECB0( void *lock );
 
 struct Rva00815B50Comm
 {
-	char m_head[ 0x5C ];
+	char m_head[ 0x48 ];
+	struct Rva007FD4E0Socket *m_socketAlias; /* +0x48 */
+	char m_gapHead[ 0x10 ];
 	/* Byte and packet counters, both incremented by the send at 0x00815680
 	 * and by nothing else here. */
 	int m_bytesSent;                /* +0x5C */
@@ -87,6 +89,13 @@ struct Rva00815B50Comm
 	char m_gap2[ 0x120 ];
 	char m_lock[ 4 ];               /* +0x1EC */
 };
+
+void Rva008154F0( struct Rva00815B50Comm *comm,
+	struct Rva007FD4E0Socket *socket )
+{
+	comm->m_socket = socket;
+	comm->m_socketAlias = socket;
+}
 
 void Rva00815BB0( struct Rva00815B50Comm *comm );
 

--- a/Code/Libraries/Source/DirtySock/Y4CommRingIdle.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommRingIdle.c
@@ -100,6 +100,12 @@ void Rva008154F0( struct Rva00815B50Comm *comm,
 	comm->m_socketAlias = socket;
 }
 
+void Rva00815730( struct Rva00815B50Comm *comm, void *value )
+{
+	comm->m_value = value;
+	comm->m_flags |= 2;
+}
+
 void Rva00815BB0( struct Rva00815B50Comm *comm );
 
 /* The socket callback.  Its first two arguments -- the handle and the event

--- a/Code/Libraries/Source/DirtySock/Y4CommRingIdle.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommRingIdle.c
@@ -93,6 +93,8 @@ struct Rva00815B50Comm
 	void *m_value;                  /* +0x218 */
 };
 
+void Rva007FD3F0( struct Rva007FD4E0Socket *socket );
+
 void Rva008154F0( struct Rva00815B50Comm *comm,
 	struct Rva007FD4E0Socket *socket )
 {
@@ -104,6 +106,17 @@ void Rva00815730( struct Rva00815B50Comm *comm, void *value )
 {
 	comm->m_value = value;
 	comm->m_flags |= 2;
+}
+
+int Rva00815790( struct Rva00815B50Comm *comm )
+{
+	if ( comm->m_socket != 0 )
+	{
+		Rva007FD3F0( comm->m_socket );
+		Rva008154F0( comm, 0 );
+	}
+	comm->m_state = 0;
+	return 0;
 }
 
 void Rva00815BB0( struct Rva00815B50Comm *comm );

--- a/Code/Libraries/Source/DirtySock/Y4CommRingIdle.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommRingIdle.c
@@ -63,7 +63,7 @@ struct Rva00815B50Comm
 	 * type implies.  1 and 2 are the two halves of an unfinished connect, 3 is
 	 * established, 4 is closing. */
 	int m_state;                    /* +0x90 */
-	char m_gapA[ 0x04 ];
+	int m_sessionValue;             /* +0x94 */
 	/* THE RECEIVE QUEUE.  The dequeue at 0x00816520 compares +0xA8 against
 	 * +0xA4 to decide whether anything is waiting and reads the record at
 	 * +0xAC plus +0xA8, which is what identifies the base and the two
@@ -88,6 +88,9 @@ struct Rva00815B50Comm
 	unsigned int m_lastRecvTick;    /* +0xC8 */
 	char m_gap2[ 0x120 ];
 	char m_lock[ 4 ];               /* +0x1EC */
+	char m_gap1F0[ 0x24 ];
+	int m_flags;                    /* +0x214 */
+	void *m_value;                  /* +0x218 */
 };
 
 void Rva008154F0( struct Rva00815B50Comm *comm,
@@ -261,6 +264,19 @@ int Rva008155F0( struct Rva00815B50Comm *comm, char kind )
 	packet.m_data[ 0 ] = kind;
 
 	return Rva00815680( comm, &packet );
+}
+
+int Rva008155A0( struct Rva00815B50Comm *comm )
+{
+	if ( comm->m_state != 3 )
+	{
+		return 0;
+	}
+
+	Rva008155F0( comm, 0x14 );
+	comm->m_sessionValue = 0;
+	comm->m_state = 4;
+	return 0;
 }
 
 void *__cdecl memcpy( void *destination, const void *source,

--- a/Code/Libraries/Source/DirtySock/Y4CommSha1.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommSha1.c
@@ -17,6 +17,17 @@ struct Rva008111D0Context
 	unsigned char m_block[ 0x40 ];		/* +0x1C */
 };
 
+void Rva00811180( struct Rva008111D0Context *context )
+{
+	context->m_count = 0;
+	context->m_fill = 0;
+	context->m_state[ 0 ] = 0x67452301;
+	context->m_state[ 1 ] = 0xEFCDAB89;
+	context->m_state[ 2 ] = 0x98BADCFE;
+	context->m_state[ 3 ] = 0x10325476;
+	context->m_state[ 4 ] = 0xC3D2E1F0;
+}
+
 void Rva00811310( struct Rva008111D0Context *context,
 	const unsigned char *block );
 

--- a/Code/Libraries/Source/DirtySock/Y4CommTable.c
+++ b/Code/Libraries/Source/DirtySock/Y4CommTable.c
@@ -221,6 +221,42 @@ void __cdecl Rva00812690( struct Rva007FD4E0Socket *socket, int reason,
 extern struct Rva00812320Module *g_Rva0130AD00Module;
 extern int g_Rva0130ACFCRefCount;
 
+struct Rva00811D70Entry
+{
+	char m_gap0[ 0x08 ];
+	char m_nameA[ 0x20 ];
+	char m_nameB[ 0x20 ];
+	char m_gap48[ 0x138 ];
+	int m_value;
+	char m_gap184[ 0x1C ];
+	struct Rva00811D70Entry *m_next;
+};
+
+struct Rva00811D70List
+{
+	char m_gap0[ 0x24 ];
+	struct Rva00811D70Entry *m_first;
+};
+
+int Rva00811D70( struct Rva00811D70List *list, const char *keyA,
+	const char *keyB )
+{
+	struct Rva00811D70Entry *entry;
+
+	Rva007FEBD0( list );
+	for ( entry = list->m_first; entry != 0; entry = entry->m_next )
+	{
+		if ( ( keyA == 0 || Rva00811CE0( keyA, entry->m_nameA ) == 0 )
+			&& ( keyB == 0 || Rva00811CE0( keyB, entry->m_nameB ) == 0 ) )
+		{
+			entry->m_value = 0;
+			break;
+		}
+	}
+	Rva007FECB0( list );
+	return entry != 0 ? 0 : -1;
+}
+
 /* 0x00812320 CREATES THE MODULE, OR SHARES THE ONE THAT EXISTS.  Retail's own
  * names for the two address buffers, from the /GZ frame descriptor, are
  * bindaddr and peeraddr.

--- a/Code/Libraries/Source/DirtySock/Y4LookupTables.c
+++ b/Code/Libraries/Source/DirtySock/Y4LookupTables.c
@@ -1,0 +1,33 @@
+// cl: /Od /GZ /GS /MD /DNDEBUG
+
+int memcmp( const void *first, const void *second, unsigned int count );
+
+struct Rva0080D890Entry
+{
+	int m_value;
+	int m_length;
+	unsigned char m_bytes[ 0x10 ];
+};
+
+extern struct Rva0080D890Entry g_Rva0112C8D0[];
+
+int Rva0080D890( const void *bytes, int length )
+{
+	int result;
+	int index;
+
+	result = 0;
+	index = 0;
+	for ( ; g_Rva0112C8D0[ index ].m_value != 0; index++ )
+	{
+		if ( length >= g_Rva0112C8D0[ index ].m_length
+			&& memcmp( bytes, g_Rva0112C8D0[ index ].m_bytes,
+				g_Rva0112C8D0[ index ].m_length ) == 0 )
+		{
+			result = g_Rva0112C8D0[ index ].m_value;
+			break;
+		}
+	}
+
+	return result;
+}

--- a/Code/Libraries/Source/DirtySock/Y4MultiPrecision.c
+++ b/Code/Libraries/Source/DirtySock/Y4MultiPrecision.c
@@ -219,6 +219,22 @@ int Rva0080FED0( unsigned short *result, int limbs, const unsigned char *bytes,
 	return iNeeded;
 }
 
+void Rva0080FFB0( const unsigned short *limbs, int limbCount,
+	unsigned char *bytes, int byteCount )
+{
+	byteCount /= 2;
+	limbs += limbCount - byteCount;
+
+	for ( ; byteCount > 0; byteCount-- )
+	{
+		*bytes = (unsigned char)( *limbs >> 8 );
+		bytes++;
+		*bytes = *(const unsigned char *)limbs;
+		bytes++;
+		limbs++;
+	}
+}
+
 unsigned int Rva007FEA00( void );
 
 /* The padded block: a fixed 0x400-byte buffer with its used length beside it. */

--- a/Code/Libraries/Source/DirtySock/Y4MultiPrecision.c
+++ b/Code/Libraries/Source/DirtySock/Y4MultiPrecision.c
@@ -1,4 +1,4 @@
-// cl: /Od /GZ /MD /DNDEBUG
+// cl: /Od /GZ /GS /MD /DNDEBUG
 /* MULTI-PRECISION INTEGER PRIMITIVES, built /Od with /GZ.
  *
  * The representation is read out of the bodies here rather than assumed: LIMBS
@@ -233,6 +233,53 @@ void Rva0080FFB0( const unsigned short *limbs, int limbCount,
 		bytes++;
 		limbs++;
 	}
+}
+
+int Rva0080FD30( unsigned short *result, int count,
+	const unsigned short *a, const unsigned short *b );
+int Rva0080FDD0( unsigned short *result, int count,
+	const unsigned short *a, const unsigned short *b );
+void *memset( void *dest, int value, unsigned int count );
+void *memcpy( void *dest, const void *src, unsigned int count );
+
+void Rva0080FB40( unsigned short *result, int count,
+	const unsigned short *bits, const unsigned short *addend,
+	const unsigned short *modulus )
+{
+	int i;
+	int carry;
+	unsigned short first[ 0x100 ];
+	unsigned short second[ 0x100 ];
+	unsigned short *current;
+	unsigned short *other;
+
+	current = first;
+	other = second;
+	memset( current, 0, count * 2 );
+	for ( i = count * 2 * 8 - 1; i >= 0; i-- )
+	{
+		carry = Rva0080FD30( current, count, current, current );
+		if ( Rva0080FDD0( other, count, current, modulus ) == 0
+			|| carry != 0 )
+		{
+			unsigned short *swap = current;
+			current = other;
+			other = swap;
+		}
+
+		if ( Rva0080FE70( bits, count, i ) != 0 )
+		{
+			carry = Rva0080FD30( current, count, current, addend );
+			if ( Rva0080FDD0( other, count, current, modulus ) == 0
+				|| carry != 0 )
+			{
+				unsigned short *swap = current;
+				current = other;
+				other = swap;
+			}
+		}
+	}
+	memcpy( result, current, count * 2 );
 }
 
 unsigned int Rva007FEA00( void );

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -23,3 +23,11 @@ int Rva0080E300(const int *crypto, int length)
 		length -= 8;
 	return length;
 }
+
+void Rva0080F300(void *state, unsigned char *data, int length);
+
+void Rva0080E410(void *crypto, unsigned char *data, int length)
+{
+	if (*(int *)crypto != 0)
+		Rva0080F300((unsigned char *)crypto + 0x10A, data, length);
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -61,3 +61,12 @@ void Rva0080F530(void *dest, const void *src, int length)
 {
 	memcpy(dest, src, length);
 }
+
+void Rva0080F3D0(unsigned char *state, const void *first, int firstLength,
+	const void *second, int secondLength)
+{
+	*(int *)(state + 0x400) = firstLength;
+	*(int *)(state + 0x488) = secondLength;
+	memcpy(state + 0x404, first, firstLength);
+	memcpy(state + 0x48C, second, secondLength);
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -79,3 +79,12 @@ int Rva0080DF70(const unsigned char *source, void *first, void *second)
 		memcpy(second, source + 0x20, 0x34);
 	return 1;
 }
+
+int Rva0080DC90(const unsigned char *first, const void *second,
+	unsigned char *combined)
+{
+	memcpy(combined, first, 0x20);
+	memcpy(combined + 0x20, second, 0x10);
+	memcpy(combined + 0x30, first, 0x20);
+	return 0x50;
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -9,3 +9,10 @@ int Rva008118F0(void)
 {
 	return -1;
 }
+
+int Rva0080E330(void *crypto, int length)
+{
+	if (*(int *)crypto != 0)
+		length += 8;
+	return length;
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -70,3 +70,12 @@ void Rva0080F3D0(unsigned char *state, const void *first, int firstLength,
 	memcpy(state + 0x404, first, firstLength);
 	memcpy(state + 0x48C, second, secondLength);
 }
+
+int Rva0080DF70(const unsigned char *source, void *first, void *second)
+{
+	if (first != 0)
+		memcpy(first, source, 0x20);
+	if (second != 0)
+		memcpy(second, source + 0x20, 0x34);
+	return 1;
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -25,6 +25,7 @@ int Rva0080E300(const int *crypto, int length)
 }
 
 void Rva0080F300(void *state, unsigned char *data, int length);
+void Rva0080F200(void *state, const unsigned char *key, int length, int rounds);
 
 void Rva0080E410(void *crypto, unsigned char *data, int length)
 {
@@ -39,4 +40,17 @@ void Rva0080E1C0(int *crypto, unsigned char *data, int length)
 		Rva0080F300((unsigned char *)crypto + 8, data, length);
 		crypto[1] = 1;
 	}
+}
+
+int Rva0080DFC0(int *crypto, const unsigned char *key)
+{
+	crypto[0] = 0;
+	if (key != 0)
+	{
+		crypto[0] = 1;
+		crypto[1] = 0;
+		Rva0080F200((unsigned char *)crypto + 0x10A, key, 0x10, -1);
+		Rva0080F200((unsigned char *)crypto + 8, key + 0x10, 0x10, -1);
+	}
+	return crypto[0];
 }

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -31,3 +31,12 @@ void Rva0080E410(void *crypto, unsigned char *data, int length)
 	if (*(int *)crypto != 0)
 		Rva0080F300((unsigned char *)crypto + 0x10A, data, length);
 }
+
+void Rva0080E1C0(int *crypto, unsigned char *data, int length)
+{
+	if (crypto[0] != 0)
+	{
+		Rva0080F300((unsigned char *)crypto + 8, data, length);
+		crypto[1] = 1;
+	}
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -4,3 +4,8 @@ int Rva008118D0(void)
 {
 	return -1;
 }
+
+int Rva008118F0(void)
+{
+	return -1;
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -28,6 +28,8 @@ int Rva0080E300(const int *crypto, int length)
 
 void Rva0080F300(void *state, unsigned char *data, int length);
 void Rva0080F200(void *state, const unsigned char *key, int length, int rounds);
+void Rva0080E500(void *object);
+void Rva007F0030(void *object);
 
 void Rva0080E410(void *crypto, unsigned char *data, int length)
 {
@@ -87,4 +89,10 @@ int Rva0080DC90(const unsigned char *first, const void *second,
 	memcpy(combined + 0x20, second, 0x10);
 	memcpy(combined + 0x30, first, 0x20);
 	return 0x50;
+}
+
+void Rva0080E4D0(void *object)
+{
+	Rva0080E500(object);
+	Rva007F0030(object);
 }

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -1,0 +1,6 @@
+// cl: /Od /GZ /MD /DNDEBUG
+
+int Rva008118D0(void)
+{
+	return -1;
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -30,6 +30,7 @@ void Rva0080F300(void *state, unsigned char *data, int length);
 void Rva0080F200(void *state, const unsigned char *key, int length, int rounds);
 void Rva0080E500(void *object);
 void Rva007F0030(void *object);
+void Rva00812CD0(void *object);
 
 void Rva0080E410(void *crypto, unsigned char *data, int length)
 {
@@ -95,4 +96,13 @@ void Rva0080E4D0(void *object)
 {
 	Rva0080E500(object);
 	Rva007F0030(object);
+}
+
+void Rva0080F0D0(unsigned char *object)
+{
+	if (*(void **)(object + 0x64) != 0)
+	{
+		Rva00812CD0(*(void **)(object + 0x64));
+		*(void **)(object + 0x64) = 0;
+	}
 }

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -16,3 +16,10 @@ int Rva0080E330(void *crypto, int length)
 		length += 8;
 	return length;
 }
+
+int Rva0080E300(const int *crypto, int length)
+{
+	if (crypto[0] != 0 && crypto[1] != 0 && length >= 8)
+		length -= 8;
+	return length;
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -1,5 +1,7 @@
 // cl: /Od /GZ /MD /DNDEBUG
 
+void *memcpy(void *dest, const void *src, unsigned int count);
+
 int Rva008118D0(void)
 {
 	return -1;
@@ -53,4 +55,9 @@ int Rva0080DFC0(int *crypto, const unsigned char *key)
 		Rva0080F200((unsigned char *)crypto + 8, key + 0x10, 0x10, -1);
 	}
 	return crypto[0];
+}
+
+void Rva0080F530(void *dest, const void *src, int length)
+{
+	memcpy(dest, src, length);
 }

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -128,3 +128,24 @@ void Rva0080EEF0(char **slot, const char *text)
 	*slot = (char *)Rva007F0000(strlen(text) + 1);
 	strcpy(*slot, text);
 }
+
+int Rva007FDB60(void *socket, int selector, void *buffer, int bufferSize);
+
+int Rva0080DBF0(unsigned char *object, int selector, void *buffer,
+	int bufferSize)
+{
+	int result;
+
+	result = -1;
+	if (*(void **)object != 0)
+	{
+		result = Rva007FDB60(*(void **)object, selector, buffer, bufferSize);
+		if (selector == 'stat' && *(int *)(object + 0x118) == 1)
+			result = 0;
+		if (selector == 'stat' && result > 0
+			&& *(int *)(object + 0x118) != 0x14
+			&& *(int *)(object + 0x118) != 0x10)
+			result = 0;
+	}
+	return result;
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -1,6 +1,7 @@
 // cl: /Od /GZ /MD /DNDEBUG
 
 void *memcpy(void *dest, const void *src, unsigned int count);
+void *memset(void *dest, int value, unsigned int count);
 unsigned int strlen(const char *text);
 char *strcpy(char *dest, const char *src);
 
@@ -168,4 +169,19 @@ void Rva0080DCE0(unsigned char *dest, const char *source,
 			j = (j + 1) % 0x20;
 		}
 	}
+}
+
+int NetGameUtilControl(void *object, int selector, int value);
+
+void *Rva0080E440(void)
+{
+	void *object;
+
+	object = Rva007F0000(0xC0);
+	if (object != 0)
+		memset(object, 0, 0xC0);
+	NetGameUtilControl(object, 'mwid', 0xF0);
+	NetGameUtilControl(object, 'minp', 0x20);
+	NetGameUtilControl(object, 'mout', 0x20);
+	return object;
 }

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -372,3 +372,42 @@ int Rva0080DA50(unsigned char *object, char *output, int length)
 		output[result] = 0;
 	return result;
 }
+
+char *strchr(const char *text, int character);
+char *strstr(const char *text, const char *find);
+void *Rva00812320(int entries);
+void Rva008119A0(void *table, const char *name, const char *alias,
+	int value, const char *templates, int extra);
+extern char *g_Rva012C47A4;
+
+void Rva0080EF50(unsigned char *object, const char *name, char *alias,
+	int value)
+{
+	char *found;
+	char *dest;
+	char defaultName[0x100];
+	const char *source;
+
+	if (*(void **)(object + 0x64) == 0)
+		*(void **)(object + 0x64) = Rva00812320(0x10);
+	if (alias == 0 || *alias == 0)
+	{
+		sprintf(defaultName, "Default Name");
+		if (*(char **)object != 0)
+			source = *(char **)object;
+		else
+			source = g_Rva012C47A4;
+		found = strstr(source, defaultName);
+		if (found != 0)
+		{
+			found = strchr(found, ':') + 1;
+			for (dest = defaultName; *found >= ' '; found++, dest++)
+				*dest = *found;
+			*dest = 0;
+		}
+		alias = defaultName;
+	}
+	strcpy((char *)object + 4, name);
+	Rva008119A0(*(void **)(object + 0x64), name, alias, value,
+		"TCP:~1:1024\tUDP:~1:1024", *(int *)(object + 0x8C));
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -1,4 +1,4 @@
-// cl: /Od /GZ /MD /DNDEBUG
+// cl: /Od /GZ /GS /MD /DNDEBUG
 
 void *memcpy(void *dest, const void *src, unsigned int count);
 void *memset(void *dest, int value, unsigned int count);
@@ -223,4 +223,24 @@ void Rva0080E500(unsigned char *object)
 		*(void **)(object + 0x64) = 0;
 	}
 	*(int *)(object + 0x7C) = 0;
+}
+
+void Rva00810020(void *context);
+void Rva00810060(void *context, const unsigned char *data, int length);
+void Rva00810FF0(void *context, char *out, int outSize);
+
+int Rva0080E350(const int *crypto, unsigned char *data, int length)
+{
+	unsigned char context[0x54];
+	int payloadLength;
+
+	payloadLength = length - 8;
+	if (*crypto == 0)
+		return 0;
+	if (payloadLength < 0)
+		return -1;
+	Rva00810020(context);
+	Rva00810060(context, data, payloadLength);
+	Rva00810FF0(context, (char *)data + payloadLength, 8);
+	return 0;
 }

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -76,6 +76,16 @@ void Rva0080F3D0(unsigned char *state, const void *first, int firstLength,
 	memcpy(state + 0x48C, second, secondLength);
 }
 
+void Rva0080F5A0(unsigned char *state, unsigned char *owner,
+	const unsigned char *first, int firstLength,
+	const unsigned char *second, int secondLength);
+
+void Rva0080F550(unsigned char *state)
+{
+	Rva0080F5A0(state, state, state + 0x404, *(int *)(state + 0x400),
+		state + 0x48C, *(int *)(state + 0x488));
+}
+
 int Rva0080DF70(const unsigned char *source, void *first, void *second)
 {
 	if (first != 0)

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -1,6 +1,8 @@
 // cl: /Od /GZ /MD /DNDEBUG
 
 void *memcpy(void *dest, const void *src, unsigned int count);
+unsigned int strlen(const char *text);
+char *strcpy(char *dest, const char *src);
 
 int Rva008118D0(void)
 {
@@ -105,4 +107,14 @@ void Rva0080F0D0(unsigned char *object)
 		Rva00812CD0(*(void **)(object + 0x64));
 		*(void **)(object + 0x64) = 0;
 	}
+}
+
+void *Rva007F0000(unsigned int size);
+
+void Rva0080EEF0(char **slot, const char *text)
+{
+	if (*slot != 0)
+		Rva007F0030(*slot);
+	*slot = (char *)Rva007F0000(strlen(text) + 1);
+	strcpy(*slot, text);
 }

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -2,6 +2,7 @@
 
 void *memcpy(void *dest, const void *src, unsigned int count);
 void *memset(void *dest, int value, unsigned int count);
+int memcmp(const void *first, const void *second, unsigned int count);
 unsigned int strlen(const char *text);
 char *strcpy(char *dest, const char *src);
 
@@ -242,5 +243,22 @@ int Rva0080E350(const int *crypto, unsigned char *data, int length)
 	Rva00810020(context);
 	Rva00810060(context, data, payloadLength);
 	Rva00810FF0(context, (char *)data + payloadLength, 8);
+	return 0;
+}
+
+int Rva0080E200(const int *crypto, const unsigned char *data, int length)
+{
+	unsigned char context[0x54];
+	char digest[0x10];
+
+	if (crypto[0] == 0 || crypto[1] == 0)
+		return 0;
+	if (length < 8)
+		return -1;
+	Rva00810020(context);
+	Rva00810060(context, data, length - 8);
+	Rva00810FF0(context, digest, 0x10);
+	if (memcmp(data + length - 8, digest, 8) != 0)
+		return -2;
 	return 0;
 }

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -3,6 +3,7 @@
 void *memcpy(void *dest, const void *src, unsigned int count);
 void *memset(void *dest, int value, unsigned int count);
 int memcmp(const void *first, const void *second, unsigned int count);
+int sprintf(char *buffer, const char *format, ...);
 unsigned int strlen(const char *text);
 char *strcpy(char *dest, const char *src);
 
@@ -261,4 +262,36 @@ int Rva0080E200(const int *crypto, const unsigned char *data, int length)
 	if (memcmp(data + length - 8, digest, 8) != 0)
 		return -2;
 	return 0;
+}
+
+void Rva0080DD80(unsigned char *output, const unsigned char *key,
+	int value, const char *name)
+{
+	unsigned char context[0x54];
+	unsigned char rc4[0x102];
+	char text[0x100];
+	int combinedLength;
+
+	sprintf(text, "send-%s-send", name);
+	Rva00810020(context);
+	Rva00810060(context, (const unsigned char *)text, -1);
+	Rva00810FF0(context, (char *)output, 0x10);
+
+	sprintf(text, "recv-%s-recv", name);
+	Rva00810020(context);
+	Rva00810060(context, (const unsigned char *)text, -1);
+	Rva00810FF0(context, (char *)output + 0x10, 0x10);
+
+	memcpy(output + 0x30, output, 0x20);
+	*(int *)(output + 0x50) = value;
+
+	sprintf(text, "iv-%s-iv", name);
+	Rva00810020(context);
+	Rva00810060(context, (const unsigned char *)text, -1);
+	Rva00810FF0(context, (char *)output + 0x20, 0x10);
+
+	combinedLength = Rva0080DC90(key, output + 0x20,
+		(unsigned char *)text);
+	Rva0080F200(rc4, (const unsigned char *)text, combinedLength, -1);
+	Rva0080F300(rc4, output + 0x30, 0x24);
 }

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -149,3 +149,23 @@ int Rva0080DBF0(unsigned char *object, int selector, void *buffer,
 	}
 	return result;
 }
+
+void Rva0080DCE0(unsigned char *dest, const char *source,
+	unsigned int length)
+{
+	unsigned int i;
+	unsigned int j;
+	const char *p;
+
+	if (length >= 0x20)
+		memcpy(dest, source, 0x20);
+	else
+	{
+		p = source;
+		for (i = 0, j = 0; i != length; i++)
+		{
+			dest[j] ^= p[i];
+			j = (j + 1) % 0x20;
+		}
+	}
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -295,3 +295,30 @@ void Rva0080DD80(unsigned char *output, const unsigned char *key,
 	Rva0080F200(rc4, (const unsigned char *)text, combinedLength, -1);
 	Rva0080F300(rc4, output + 0x30, 0x24);
 }
+
+int Rva0080E030(int *crypto, const unsigned char *input,
+	const unsigned char *key, unsigned int totalLength)
+{
+	unsigned char rc4[0x102];
+	unsigned char header[0x34];
+	int combinedLength;
+	unsigned char combined[0x100];
+
+	if (input == 0)
+	{
+		crypto[0] = 0;
+		return 0;
+	}
+	memcpy(header, input, 0x34);
+	combinedLength = Rva0080DC90(key, header, combined);
+	Rva0080F200(rc4, combined, combinedLength, -1);
+	Rva0080F300(rc4, header + 0x10, 0x24);
+	if (*(unsigned int *)(header + 0x30) > totalLength
+		|| totalLength - *(unsigned int *)(header + 0x30) > 0xE10)
+		return -1;
+	Rva0080F200((unsigned char *)crypto + 8, header + 0x10, 0x10, -1);
+	Rva0080F200((unsigned char *)crypto + 0x10A, header + 0x20, 0x10, -1);
+	crypto[0] = 1;
+	crypto[1] = 0;
+	return 1;
+}

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -31,7 +31,7 @@ int Rva0080E300(const int *crypto, int length)
 
 void Rva0080F300(void *state, unsigned char *data, int length);
 void Rva0080F200(void *state, const unsigned char *key, int length, int rounds);
-void Rva0080E500(void *object);
+void Rva0080E500(unsigned char *object);
 void Rva007F0030(void *object);
 void Rva00812CD0(void *object);
 
@@ -184,4 +184,43 @@ void *Rva0080E440(void)
 	NetGameUtilControl(object, 'minp', 0x20);
 	NetGameUtilControl(object, 'mout', 0x20);
 	return object;
+}
+
+struct Rva0080E500Callback
+{
+	void *field0;
+	void (__cdecl *cleanup)(struct Rva0080E500Callback *callback);
+};
+
+struct Rva0080E500Slot
+{
+	struct Rva0080E500Callback *callback;
+	int field4;
+	int field8;
+};
+
+void Rva0080E500(unsigned char *object)
+{
+	int i;
+
+	for (i = 0; i < 4; i++)
+	{
+		if (((struct Rva0080E500Slot *)(object + 0x90))[i].callback != 0)
+		{
+			((struct Rva0080E500Slot *)(object + 0x90))[i].callback->cleanup(
+				((struct Rva0080E500Slot *)(object + 0x90))[i].callback);
+		}
+		((struct Rva0080E500Slot *)(object + 0x90))[i].callback = 0;
+	}
+	if (*(void **)(object + 0x68) != 0)
+	{
+		Rva00812CD0(*(void **)(object + 0x68));
+		*(void **)(object + 0x68) = 0;
+	}
+	if (*(void **)(object + 0x64) != 0)
+	{
+		Rva00812CD0(*(void **)(object + 0x64));
+		*(void **)(object + 0x64) = 0;
+	}
+	*(int *)(object + 0x7C) = 0;
 }

--- a/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
+++ b/Code/Libraries/Source/DirtySock/Y5SmallHelpers.c
@@ -322,3 +322,53 @@ int Rva0080E030(int *crypto, const unsigned char *input,
 	crypto[1] = 0;
 	return 1;
 }
+
+unsigned char *Rva0080C6F0(unsigned char *object);
+int Rva007FDA50(void *socket, char *buffer, int length, int flags,
+	void *from, int *fromLength);
+
+int Rva0080DA50(unsigned char *object, char *output, int length)
+{
+	int result;
+	unsigned char *state;
+
+	result = -1;
+	state = *(unsigned char **)(object + 0x120);
+	if (*(int *)(object + 0x118) == 0x10)
+	{
+		result = 0;
+		if (*(void **)(state + 0x801C) == 0)
+		{
+			if (*(int *)(state + 0x400C) == *(int *)(state + 0x4010))
+			{
+				if (*(int *)(state + 0x4010) > 4)
+				{
+					*(int *)(state + 0x4014) = 0;
+					*(unsigned char **)(state + 0x801C) = Rva0080C6F0(object);
+				}
+				else if (*(int *)(object + 0x11C) != 0)
+					result = -1;
+			}
+		}
+		if (*(void **)(state + 0x801C) != 0)
+		{
+			result = *(int *)(state + 0x4010) - *(int *)(state + 0x4014);
+			if (length < result)
+				result = length;
+			memcpy(output, *(unsigned char **)(state + 0x801C)
+				+ *(int *)(state + 0x4014), result);
+			*(int *)(state + 0x4014) += result;
+			if (*(int *)(state + 0x4014) >= *(int *)(state + 0x4010))
+			{
+				*(int *)(state + 0x4010) = 0;
+				*(int *)(state + 0x400C) = 0;
+				*(void **)(state + 0x801C) = 0;
+			}
+		}
+	}
+	if (*(int *)(object + 0x118) == 0x14)
+		result = Rva007FDA50(*(void **)object, output, length, 0, 0, 0);
+	if (result > 0 && result < length)
+		output[result] = 0;
+	return result;
+}

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -76954,3 +76954,4 @@ __imp__strrchr,0x013594C8,pin
 _Rva0080E500,0x0080E500,address-derived cleanup helper invoked immediately before release by 0x0080E4D0
 _Rva00812CD0,0x00812CD0,address-derived cleanup helper invoked for the owned field at offset 0x64 by 0x0080F0D0
 _Rva0080F5A0,0x0080F5A0,address-derived DirtySock state operation called by the wrapper at 0x0080F550
+_Rva0080C6F0,0x0080C6F0,address-derived DirtySock buffered receive helper called by 0x0080DA50

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -76960,3 +76960,5 @@ _g_Rva012C47A4,0x012C47A4,DirtySock default alias-list pointer used by 0x0080EF5
 _Rva0080FD30,0x0080FD30,address-derived multi-precision addition helper called by 0x0080FB40
 _Rva0080FDD0,0x0080FDD0,address-derived multi-precision subtraction helper called by 0x0080FB40
 _Rva0080ADE0,0x0080ADE0,address-derived comm object state release helper called by 0x0080B050
+_Rva007FD2D0,0x007FD2D0,address-derived socket creation helper called by 0x0080B150
+_Rva007FD510,0x007FD510,address-derived socket bind helper called by 0x0080B150

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -76957,3 +76957,5 @@ _Rva0080F5A0,0x0080F5A0,address-derived DirtySock state operation called by the 
 _Rva0080C6F0,0x0080C6F0,address-derived DirtySock buffered receive helper called by 0x0080DA50
 _Rva008119A0,0x008119A0,address-derived DirtySock table insertion helper called by 0x0080EF50
 _g_Rva012C47A4,0x012C47A4,DirtySock default alias-list pointer used by 0x0080EF50
+_Rva0080FD30,0x0080FD30,address-derived multi-precision addition helper called by 0x0080FB40
+_Rva0080FDD0,0x0080FDD0,address-derived multi-precision subtraction helper called by 0x0080FB40

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -76965,3 +76965,5 @@ _Rva007FD510,0x007FD510,address-derived socket bind helper called by 0x0080B150
 _Rva007FD7A0,0x007FD7A0,address-derived socket mode helper called by 0x0080B460
 _Rva007FD7D0,0x007FD7D0,address-derived socket accept helper called by 0x0080B0A0
 _g_Rva0112C8D0,0x0112C8D0,address-derived terminated lookup table read by 0x0080D890
+_Rva0080C390,0x0080C390,address-derived comm buffered-send helper called by 0x0080D980
+_Rva007FD920,0x007FD920,address-derived socket send helper called by 0x0080D980

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -76959,3 +76959,4 @@ _Rva008119A0,0x008119A0,address-derived DirtySock table insertion helper called 
 _g_Rva012C47A4,0x012C47A4,DirtySock default alias-list pointer used by 0x0080EF50
 _Rva0080FD30,0x0080FD30,address-derived multi-precision addition helper called by 0x0080FB40
 _Rva0080FDD0,0x0080FDD0,address-derived multi-precision subtraction helper called by 0x0080FB40
+_Rva0080ADE0,0x0080ADE0,address-derived comm object state release helper called by 0x0080B050

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -76963,3 +76963,4 @@ _Rva0080ADE0,0x0080ADE0,address-derived comm object state release helper called 
 _Rva007FD2D0,0x007FD2D0,address-derived socket creation helper called by 0x0080B150
 _Rva007FD510,0x007FD510,address-derived socket bind helper called by 0x0080B150
 _Rva007FD7A0,0x007FD7A0,address-derived socket mode helper called by 0x0080B460
+_Rva007FD7D0,0x007FD7D0,address-derived socket accept helper called by 0x0080B0A0

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -76964,3 +76964,4 @@ _Rva007FD2D0,0x007FD2D0,address-derived socket creation helper called by 0x0080B
 _Rva007FD510,0x007FD510,address-derived socket bind helper called by 0x0080B150
 _Rva007FD7A0,0x007FD7A0,address-derived socket mode helper called by 0x0080B460
 _Rva007FD7D0,0x007FD7D0,address-derived socket accept helper called by 0x0080B0A0
+_g_Rva0112C8D0,0x0112C8D0,address-derived terminated lookup table read by 0x0080D890

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -76962,3 +76962,4 @@ _Rva0080FDD0,0x0080FDD0,address-derived multi-precision subtraction helper calle
 _Rva0080ADE0,0x0080ADE0,address-derived comm object state release helper called by 0x0080B050
 _Rva007FD2D0,0x007FD2D0,address-derived socket creation helper called by 0x0080B150
 _Rva007FD510,0x007FD510,address-derived socket bind helper called by 0x0080B150
+_Rva007FD7A0,0x007FD7A0,address-derived socket mode helper called by 0x0080B460

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -76952,3 +76952,4 @@ __imp__strrchr,0x013594C8,pin
 ??0?$BannerStringBase@D@@AAE@PBD@Z,0x00888BC0,BannerUI one-dword retail string constructor alias used for by-value APT window arguments
 ?registerBannerAptCallbacks@@YAXXZ,0x0003DE6F,BannerUI init ILT to the helper that registers AptBannerUI OnBttnBanner and OnInitialized callbacks
 _Rva0080E500,0x0080E500,address-derived cleanup helper invoked immediately before release by 0x0080E4D0
+_Rva00812CD0,0x00812CD0,address-derived cleanup helper invoked for the owned field at offset 0x64 by 0x0080F0D0

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -76953,3 +76953,4 @@ __imp__strrchr,0x013594C8,pin
 ?registerBannerAptCallbacks@@YAXXZ,0x0003DE6F,BannerUI init ILT to the helper that registers AptBannerUI OnBttnBanner and OnInitialized callbacks
 _Rva0080E500,0x0080E500,address-derived cleanup helper invoked immediately before release by 0x0080E4D0
 _Rva00812CD0,0x00812CD0,address-derived cleanup helper invoked for the owned field at offset 0x64 by 0x0080F0D0
+_Rva0080F5A0,0x0080F5A0,address-derived DirtySock state operation called by the wrapper at 0x0080F550

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -76955,3 +76955,5 @@ _Rva0080E500,0x0080E500,address-derived cleanup helper invoked immediately befor
 _Rva00812CD0,0x00812CD0,address-derived cleanup helper invoked for the owned field at offset 0x64 by 0x0080F0D0
 _Rva0080F5A0,0x0080F5A0,address-derived DirtySock state operation called by the wrapper at 0x0080F550
 _Rva0080C6F0,0x0080C6F0,address-derived DirtySock buffered receive helper called by 0x0080DA50
+_Rva008119A0,0x008119A0,address-derived DirtySock table insertion helper called by 0x0080EF50
+_g_Rva012C47A4,0x012C47A4,DirtySock default alias-list pointer used by 0x0080EF50

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -76951,3 +76951,4 @@ __imp__strrchr,0x013594C8,pin
 ??A?$map@HVPSPlayerStats@@U?$less@H@_STL@@V?$allocator@U?$pair@$$CBHVPSPlayerStats@@@_STL@@@3@@_STL@@QAEAAVPSPlayerStats@@ABH@Z,0x0002D64B,GameSpyPSMessageQueue player-stats map subscript ILT; caller branches assign stats or merged stats
 ??0?$BannerStringBase@D@@AAE@PBD@Z,0x00888BC0,BannerUI one-dword retail string constructor alias used for by-value APT window arguments
 ?registerBannerAptCallbacks@@YAXXZ,0x0003DE6F,BannerUI init ILT to the helper that registers AptBannerUI OnBttnBanner and OnInitialized callbacks
+_Rva0080E500,0x0080E500,address-derived cleanup helper invoked immediately before release by 0x0080E4D0


### PR DESCRIPTION
## Summary

- reconstruct 45 DirtySock digest, crypto, buffer, table, socket, parser, transport, and cleanup helpers as clean C/C++
- keep each reconstructed body in its own independently verified commit
- replace each `reverse/functions.csv` dump claim in place, preserving the upstream CRLF/LF byte counts and avoiding broad EOL or row-relocation churn
- add sixteen address-derived callee/global pins, all checked by the pin-consistency gate

## Coverage

- reconstructable authored coverage: +5,429 bytes (+0.06 percentage points)
- C++ exact coverage: +5,429 bytes (+0.04 percentage points)
- branch diff: 895 insertions, 48 deletions across eleven files
- `reverse/functions.csv`: exactly 45 in-place reconstruction row replacements

## Verification

- `python3 tools/check_csv.py`: OK
- `python3 tools/pin_consistency.py --check`: OK
- targeted builds for every touched DirtySock translation unit: all reconstructed bodies byte-match retail
- every body passed its commit and push hooks as an independent commit
- full build: 161703/161703 functions matched retail; string references, pin consistency, source claims, and no-op patch passed

The repository-wide full gate still reports 22 unrelated DIR32 consistency findings. The branch is rebased on current upstream `master`, including its ledger repair, and contains only the DirtySock reconstruction changes.
