### PR TITLE
Open-BFME5: convert counted 16-byte node copy walk

### DIFF
--- a/Code/GameEngine/Source/Common/BfmeThreeHundredSeventy.cpp
+++ b/Code/GameEngine/Source/Common/BfmeThreeHundredSeventy.cpp
@@ -28,3 +28,19 @@ void bfmeCopyWE(BfmeNodeWE *first, BfmeNodeWE *last, BfmeDestWE *to)
 		++first;
 	}
 }
+
+BfmeNodeWE *bfmeUninitCopyWE(BfmeNodeWE *first, BfmeNodeWE *last, BfmeNodeWE *to)
+{
+	int count = last - first;
+
+	while (count > 0)
+	{
+		to->bfmeOneWE((BfmeDestWE *)first);
+		to->m_bfmeSub.bfmeTwoWE(&first->m_bfmeSub);
+		++first;
+		++to;
+		--count;
+	}
+
+	return to;
+}


### PR DESCRIPTION
Replaces the 73-byte generated MASM body at RVA `0x000DE710` with behaviorally and byte-identical C++. The reconstruction preserves the retail precomputed element count, two member-copy calls per 16-byte node, and advanced destination return.\n\nVerified by the repository pre-commit and pre-push gates with MSVC 7.1: 2/2 functions matched, ledger and identity checks clean.