### PR TITLE
Open-BFME5: convert 0x006E1990 float equality

### DIFF
--- a/Code/GameEngine/Source/Common/Rva006E1990FloatEq.cpp
+++ b/Code/GameEngine/Source/Common/Rva006E1990FloatEq.cpp
@@ -1,0 +1,16 @@
+// cl: /O2 /Ob0
+
+class Rva006E1990
+{
+public:
+	bool ok();
+
+private:
+	char m_pad[0x40];
+	float m_val;
+};
+
+bool Rva006E1990::ok()
+{
+	return m_val == 100.0f;
+}


### PR DESCRIPTION
Verified conversion of the 18-byte gen_asm dump at `0x006E1990` to thiscall C++.

`Rva006E1990::ok()` compares the float at `+0x40` with `100.0f`. MSVC 7.1 emits `cmp dword` against `0x42c80000`. `./build.sh` byte-matches the body.

One function, one commit, as specified in AGENTS.md.