### PR TITLE
Open-BFME5: convert 0x0056C090 thiscall state setter

### DIFF
--- a/Code/GameEngine/Source/Common/Bfme/Rva0056C090SetState.cpp
+++ b/Code/GameEngine/Source/Common/Bfme/Rva0056C090SetState.cpp
@@ -1,0 +1,21 @@
+// cl: /DNDEBUG /MD /EHsc
+
+class Rva0056C090
+{
+public:
+	int helper();
+	void update(int unused);
+
+private:
+	unsigned char m_pad[0x258];
+	int m_state;
+};
+
+void Rva0056C090::update(int unused)
+{
+	if (m_state == 0)
+	{
+		if (helper())
+			m_state = 12;
+	}
+}

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -78912,6 +78912,7 @@ name,address,notes
 ?helper@ControlBar@@QAEXXZ,0x00038F4B,setSquishedControlBarConfig helper call; ILT thunk for body 0x004C1920
 ?helper@Gen_00942BC0@@AAEXPAHPAX11H@Z,0x00942430,address-derived helper call recovered from 0x00942BC0
 ?helper@PoisonedBehaviorOwnerShim@@QAE?AW4UpdateSleepTime@@HPAXHH@Z,0x000202A7,PoisonedBehavior update sleep-time helper shim
+?helper@Rva0056C090@@QAEHXZ,0x00003EA4,Open-BFME5 thunk to 0x0056AB50
 ?helper_006f4660@@YGXHHHH@Z,0x0093EB50,Open-BFME5 pin for 0x006F4660 four-arg wrapper
 ?hide@AptPalantir@@QAEX_N@Z,0x0001420E,ILT to body 0x00592CD0; the AptPalantir callback table at 0x00565F30 names its RenderRadar RenderRadarViewBox ClipRadar and OnInitialized methods; HideControlBar passes TRUE and ShowControlBar passes FALSE
 ?hide@BannerUI@@QAEX_N@Z,0x0003A062,ILT to body 0x005839D0; BannerUI is independently identified by its existing parser and constructor sources; HideControlBar passes TRUE and ShowControlBar passes FALSE


### PR DESCRIPTION
Verified conversion of the 36-byte gen_asm dump at `0x0056C090` to thiscall C++.

If the int at `+0x258` is zero and `helper()` is nonzero, store 12. `helper` is pinned through the ILT thunk at `0x00003EA4` to `0x0056AB50`. `./build.sh` byte-matches.

One function, one commit.