### PR TITLE
Reconstruct three APT map-preview helpers (757 bytes)

### DIFF
--- a/Code/GameEngine/Source/GameClient/GUI/AptMapPreviewPictureImage.cpp
+++ b/Code/GameEngine/Source/GameClient/GUI/AptMapPreviewPictureImage.cpp
@@ -1,0 +1,140 @@
+// cl: /DNDEBUG /MD /EHsc
+
+// Recovered BFME map-picture loader at RVA 0x00520BB0 (431 bytes).
+// The descriptive _bfme_ name does not claim an original source spelling.
+// AptMapPreview's image selection caller at 0x00520E70 passes a map-name
+// string at +0x50, owns the returned Image at +0x34, and falls back to the
+// mapped image "MissingMap" when no picture is available.
+//
+// The Image layout and UV/size operations follow GameClient/Image.h; the
+// filename is the map path with its four-character extension replaced by
+// "_pic.tga". The string ABI below follows StringInline.h, with the two
+// existing public StringBase methods required by this body added locally.
+// The address-derived Rva0044F4D0 is an existing one-pointer texture-owner
+// ABI shim. Its int argument carries a filename pointer on this 32-bit target.
+//
+template <typename T> struct StringInlineData
+{
+	int m_refCount;
+	int m_length;
+	T m_text[1];
+};
+
+template <typename T> class StringBase
+{
+	friend class AsciiString;
+	friend class UnicodeString;
+
+private:
+	StringBase() : m_data( 0 ) {}
+	StringBase( const T *text );
+	StringBase( const StringBase<T> &other );
+public:
+	void removeLastChar();
+	void concat(const T *, int);
+private:
+	~StringBase();
+
+	StringInlineData<T> *m_data;
+};
+
+class AsciiString : private StringBase<char>
+{
+public:
+	AsciiString() : StringBase<char>() {}
+	AsciiString( const char *text ) : StringBase<char>( text ) {}
+	AsciiString( const AsciiString &other ) : StringBase<char>( other ) {}
+	~AsciiString() {}
+	void removeLastChar() { StringBase<char>::removeLastChar(); }
+	void concat(const char *text, int count) { StringBase<char>::concat(text, count); }
+	const char *str( void ) const { return m_data ? m_data->m_text : ""; }
+};
+
+typedef unsigned int size_t;
+void *__cdecl operator new(size_t);
+void __cdecl operator delete(void *);
+
+class GlobalData;
+extern GlobalData *TheWritableGlobalData;
+
+class FileSystem
+{
+public:
+    bool doesFileExist(const char *) const;
+};
+extern FileSystem *TheFileSystem;
+
+class TextureClass
+{
+public:
+    void Release_Ref();
+};
+
+class Rva0044F4D0
+{
+public:
+    Rva0044F4D0(int name);
+    ~Rva0044F4D0() { if (m_texture) m_texture->Release_Ref(); }
+private:
+    TextureClass *m_texture;
+};
+
+struct Coord2D { float x, y; };
+struct Region2D { Coord2D lo, hi; };
+
+class Image
+{
+public:
+    Image();
+    virtual ~Image();
+    void setName(AsciiString name);
+    void setFilename(AsciiString name);
+    void _bfme_setTexture(const Rva0044F4D0 &texture);
+    unsigned int setStatus(unsigned int bit);
+    void setUV(Region2D *uv) { if (uv) m_uv = *uv; }
+    void setTextureHeight(int height) { m_textureHeight = height; }
+    void setTextureWidth(int width) { m_textureWidth = width; }
+private:
+    AsciiString m_name;
+    AsciiString m_filename;
+    int m_textureWidth;
+    int m_textureHeight;
+    Region2D m_uv;
+    int m_imageWidth;
+    int m_imageHeight;
+    Rva0044F4D0 *m_texture;
+    unsigned int m_status;
+};
+
+
+Image *_bfme_createMapPictureImage(const AsciiString &mapName)
+{
+    if (!TheWritableGlobalData)
+        return 0;
+
+    AsciiString pictureName = mapName;
+    pictureName.removeLastChar();
+    pictureName.removeLastChar();
+    pictureName.removeLastChar();
+    pictureName.removeLastChar();
+    pictureName.concat("_pic.tga", 8);
+
+    Image *image = 0;
+    if (TheFileSystem->doesFileExist(pictureName.str()))
+    {
+        image = new Image;
+        image->setName(pictureName);
+        image->setFilename(pictureName);
+        image->_bfme_setTexture(Rva0044F4D0((int)pictureName.str()));
+        image->setStatus(2);
+        Region2D uv;
+        uv.lo.x = 0.0f;
+        uv.lo.y = 0.0f;
+        uv.hi.x = 1.0f;
+        uv.hi.y = 1.0f;
+        image->setUV(&uv);
+        image->setTextureHeight(128);
+        image->setTextureWidth(128);
+    }
+    return image;
+}

--- a/Code/GameEngine/Source/GameClient/GUI/AptMapPreviewSetMapDescription.cpp
+++ b/Code/GameEngine/Source/GameClient/GUI/AptMapPreviewSetMapDescription.cpp
@@ -1,0 +1,51 @@
+// cl: /DNDEBUG /MD
+// Recovered map-preview description update at RVA 0x005208D0.
+// Descriptive bfme names do not claim original source spellings. The metadata
+// getter calls the cached map.str text loader, then returns its first line.
+
+template <typename T> class StringBase
+{
+    friend class UnicodeString;
+private:
+    StringBase(const StringBase<T> &other);
+    ~StringBase();
+    void *m_data;
+};
+
+class UnicodeString : private StringBase<unsigned short>
+{
+public:
+    UnicodeString(const UnicodeString &other) : StringBase<unsigned short>(other) {}
+    ~UnicodeString() {}
+};
+
+class GameWindow;
+void GadgetListBoxReset(GameWindow *listbox);
+int GadgetListBoxAddEntryText(GameWindow *listbox, UnicodeString text,
+    int color, int row, int column, bool overwrite);
+
+class MapMetaData
+{
+public:
+    UnicodeString bfme_getDescriptionFirstLine();
+};
+
+class AptMapPreview
+{
+public:
+    void bfmeSetMapDescription(MapMetaData *map);
+private:
+    char m_unmodelled[0x10];
+    GameWindow *m_descriptionList;
+};
+
+void AptMapPreview::bfmeSetMapDescription(MapMetaData *map)
+{
+    if (m_descriptionList)
+    {
+        GadgetListBoxReset(m_descriptionList);
+        if (map)
+            GadgetListBoxAddEntryText(m_descriptionList,
+                map->bfme_getDescriptionFirstLine(), -1, -1, -1, true);
+    }
+}

--- a/Code/GameEngine/Source/GameClient/GUI/AptMapPreviewSetMapTitle.cpp
+++ b/Code/GameEngine/Source/GameClient/GUI/AptMapPreviewSetMapTitle.cpp
@@ -1,0 +1,40 @@
+// cl: /DNDEBUG /MD /EHsc
+// Retail RVA 0x00520920. Names prefixed with bfme describe recovered behavior;
+// the original member spelling is not known. The caller at 0x005216B0 passes
+// this map-preview object and MapMetaData, whose filename is at +0x50.
+// The display-name callee reads the player count at +0x20 and appends it.
+#include "../../../../../reference/shims/stringinline/StringInline.h"
+
+class MapMetaData
+{
+public:
+    UnicodeString bfme_getDisplayName();
+};
+
+class WindowManager
+{
+public:
+    void bfme_setAptText(const AsciiString &, const UnicodeString &);
+};
+
+extern WindowManager *g_theWindowManager;
+
+class AptMapPreview
+{
+public:
+    void bfmeSetMapTitle(MapMetaData *map);
+};
+
+void AptMapPreview::bfmeSetMapTitle(MapMetaData *map)
+{
+    if (g_theWindowManager)
+    {
+        if (map)
+        {
+            AsciiString key("APT:MapTitle");
+            g_theWindowManager->bfme_setAptText(key, map->bfme_getDisplayName());
+        }
+        else
+            g_theWindowManager->bfme_setAptText(AsciiString("APT:MapTitle"), UnicodeString(L" "));
+    }
+}

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -77393,6 +77393,7 @@ name,address,notes
 ?findLevel@ExperienceLevelSystem@@QAEPAVBfmeExperienceLevelDefinition@@ABVAsciiString@@@Z,0x000335D2,TEAM_GIVE_EXPERIENCE_LEVEL canonical lookup searches the experience-level definitions by name
 ?findLightPointLevel@@YGPAVLightPointLevel@@PAXPAVAsciiString@@@Z,0x00028AF6,Reviewed39C1A0 full153B pointer-range search and AsciiString comparison; ignoresECX andret8
 ?findMap@MapCache@@QAEPBVMapMetaData@@VAsciiString@@@Z,0x00019880
+?bfme_getDisplayName@MapMetaData@@QAE?AVUnicodeString@@XZ,0x0000A6FA,map metadata display-name accessor; ILT resolves to verified 0x00451240; filename +0x50 and player count +0x20 confirmed by 0x005216B0 and MapMetaData layout
 ?findMapping@DataChunkTableOfContents@@AAEPAVMapping@@ABVAsciiString@@@Z,0x0001587A
 ?findMemoryPool@MemoryPoolFactory@@QAEPAVMemoryPool@@PBD@Z,0x0003ADD7,pool-glue cascade callee (from retail call site)
 ?findModule@Object@@IBEPAVModule@@W4NameKeyType@@@Z,0x0002AE23

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -82302,6 +82302,8 @@ name,address,notes
 ?setMouseText@Mouse@@QAEXVUnicodeString@@PBURGBAColorInt@@1@Z,0x0002FBD0,ILT thunk to body 0x005A5950
 ?setName@BFMETransitionGroup@@QAEXVBFMETransitionAsciiString@@@Z,0x00489B60,retail TransitionGroup::setName
 ?setName@Image@@QAEXVAsciiString@@@Z,0x0003EDBA,thunk to 0x000C2420; the body is byte-identical to three other setName instantiations so the call site is what pins it - the MappedImage parser at 0x000C2480 calls this one
+?setFilename@Image@@QAEXVAsciiString@@@Z,0x00008C15,Image filename setter; ILT resolves to 0x00450270 and writes the string at Image+8
+?_bfme_setTexture@Image@@QAEXABVRva0044F4D0@@@Z,0x0002C9C1,Image texture assignment; ILT resolves to verified 0x005D2330; allocates the Image+0x2C holder then retains and replaces its texture
 ?setName@MapObject@@QAEXABVAsciiString@@@Z,0x0004340F,handleNameChange at 0x00388970 calls the MapObject name setter ILT; WorldHeightMap.cpp provides the matching setter body
 ?setName@Object@@QAEXVAsciiString@@@Z,0x00027BBA,Open-BFME5 Object by-value name setter called by replacement-state transfer at 0x001C5620
 ?setNameAndType@DictPair@Dict@@QAEXW4NameKeyType@@W4DataType@2@@Z,0x00038D02,retail DictPair::setNameAndType body (unclaimed, called by setPrep/remove)

--- a/reverse/symbols.csv
+++ b/reverse/symbols.csv
@@ -77394,6 +77394,7 @@ name,address,notes
 ?findLightPointLevel@@YGPAVLightPointLevel@@PAXPAVAsciiString@@@Z,0x00028AF6,Reviewed39C1A0 full153B pointer-range search and AsciiString comparison; ignoresECX andret8
 ?findMap@MapCache@@QAEPBVMapMetaData@@VAsciiString@@@Z,0x00019880
 ?bfme_getDisplayName@MapMetaData@@QAE?AVUnicodeString@@XZ,0x0000A6FA,map metadata display-name accessor; ILT resolves to verified 0x00451240; filename +0x50 and player count +0x20 confirmed by 0x005216B0 and MapMetaData layout
+?bfme_getDescriptionFirstLine@MapMetaData@@QAE?AVUnicodeString@@XZ,0x000036BB,ILT to 0x00452000; obtains cached map.str text and returns its prefix before the first newline
 ?findMapping@DataChunkTableOfContents@@AAEPAVMapping@@ABVAsciiString@@@Z,0x0001587A
 ?findMemoryPool@MemoryPoolFactory@@QAEPAVMemoryPool@@PBD@Z,0x0003ADD7,pool-glue cascade callee (from retail call site)
 ?findModule@Object@@IBEPAVModule@@W4NameKeyType@@@Z,0x0002AE23


### PR DESCRIPTION
This converts three assembly-backed APT map-preview helpers into verified C++: the title update, custom map picture loader, and description list update. Each function is a separate commit.

| Recovered function | RVA | Bytes |
| --- | --- | ---: |
| `AptMapPreview::bfmeSetMapTitle` | `0x00520920` | 262 |
| `_bfme_createMapPictureImage` | `0x00520BB0` | 431 |
| `AptMapPreview::bfmeSetMapDescription` | `0x005208D0` | 64 |

The title setter writes the metadata display name to `APT:MapTitle`, or a single space when no map is selected. The picture loader derives the `_pic.tga` filename, checks that it exists, and initializes the image and its texture owner. The description setter resets the list and adds the first line of the map's cached `map.str` text.

The `bfme` names describe recovered behavior; original spellings are unknown. Caller layouts, literals, and callee bodies were checked independently of byte matching. The four additive callee pins resolve through their retail ILTs; in particular, the image's `+0x2C` field points to a texture holder, and the description getter scans UTF-16 text for the first newline. The ledger rows now point to the C++ sources, with the original `Code/gen_asm` dump left intact.

Validation with MSVC 7.1 under Wine:

- Scoped `./build.sh` for all three final sources: **3/3 matched**, with all four literals and two empty-string references verified.
- Separate object audit: exact body sizes, all 757 relocated bytes match, no unresolved references, one ledger claim per body.
- `check_csv.py`, `pin_consistency.py --check`, `identity_guard.py`, and `conversion_gate.py` pass; no baseline changes.
- Normal commit and push hooks pass. The full repository build was not run.

`tools/progress.py origin/master` reports **+757 bytes / +0.01 percentage points** of recovered C++. AI-assisted contribution using Codex, including independent callee/ABI review.
