### PR TITLE
Recover GameSpy peer request and response copying in C++

### DIFF
--- a/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerRequestCopies.cpp
+++ b/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerRequestCopies.cpp
@@ -1,0 +1,62 @@
+// cl: /DNDEBUG /DWIN32 /MD /EHsc /D_STLP_USE_STATIC_LIB /Ireference/shims/sweep /Ireference/CnC_Generals_Zero_Hour/GeneralsMD/Code/Libraries/Include
+// stlport
+// Recovered from the Zero Hour PeerThread.h request layout.
+// Copyright 2025 Electronic Arts Inc. Licensed under GPL-3.0-or-later.
+//
+// The matched PeerRequest deque push_back_aux (RVA 0x00648810) calls this
+// copy constructor twice through ILT0x0003C308 -> 0x00647470, while allocating
+// 0x194-byte elements. The string/vector prefix and opaque union copy spans
+// reproduce that BFME layout without assigning meanings to unknown payloads.
+// Keeping these views local leaves the shared reference headers unchanged.
+
+#include <new>
+#include <string>
+#include <vector>
+
+typedef int Int;
+typedef bool Bool;
+typedef unsigned int UnsignedInt;
+typedef unsigned short UnsignedShort;
+static const Int MAX_SLOTS = 8;
+
+class PeerRequest
+{
+public:
+
+	int peerRequestType;
+	std::string nick;
+	std::wstring text;
+	std::string password;
+	std::string email;
+	std::string id;
+	std::string options;
+	std::string ladderIP;
+	std::string hostPingStr;
+	std::string gameOptsMapName;
+	std::string gameOptsPlayerNames[MAX_SLOTS];
+	std::vector<bool> qmMaps;
+
+	union
+	{
+		struct { Int value; } payload0;
+		struct { Int value; } payload1;
+		struct { Int value; } payload2;
+		struct { Bool value; } payload3;
+		struct { Bool value; } payload4;
+		struct { Int value; } payload5;
+		struct { Int words[8]; } payload32;
+		struct { Int words[44]; } payload176;
+		struct { Bool value; } payload9;
+		struct { Int words[23]; } payload92;
+		struct { Int words[7]; } payload28;
+		struct { Int words[2]; } payload8;
+	};
+};
+
+typedef char PeerRequestSizeCheck[sizeof(PeerRequest) == 0x194 ? 1 : -1];
+
+// forcePeerRequestCopy absent-from-retail: emission anchor for the implicit constructor.
+PeerRequest *forcePeerRequestCopy(PeerRequest *destination, const PeerRequest &source)
+{
+    return new (destination) PeerRequest(source);
+}

--- a/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerRequestCopies.cpp
+++ b/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerRequestCopies.cpp
@@ -5,7 +5,8 @@
 //
 // The matched PeerRequest deque push_back_aux (RVA 0x00648810) calls this
 // copy constructor twice through ILT0x0003C308 -> 0x00647470, while allocating
-// 0x194-byte elements. The string/vector prefix and opaque union copy spans
+// 0x194-byte elements. GameSpyPeerMessageQueue::getRequest at 0x0064C840
+// names assignment through ILT0x000336A4 -> 0x00648C00. The string/vector prefix and opaque union copy spans
 // reproduce that BFME layout without assigning meanings to unknown payloads.
 // Keeping these views local leaves the shared reference headers unchanged.
 
@@ -60,3 +61,7 @@ PeerRequest *forcePeerRequestCopy(PeerRequest *destination, const PeerRequest &s
 {
     return new (destination) PeerRequest(source);
 }
+
+// Emit the implicit assignment without introducing a wrapper function.
+PeerRequest &(PeerRequest::*forcePeerRequestAssignment)(const PeerRequest &) =
+    &PeerRequest::operator=;

--- a/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerResponseAssignment.cpp
+++ b/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerResponseAssignment.cpp
@@ -1,0 +1,60 @@
+// cl: /DNDEBUG /MD /EHsc /D_STLP_USE_STATIC_LIB
+// stlport
+// Recovered from the PeerResponse layout in the Zero Hour PeerThread.h.
+// Copyright 2025 Electronic Arts Inc. Licensed under GPL-3.0-or-later.
+//
+// The matched GameSpyPeerMessageQueue::getResponse at RVA 0x0064C910 calls
+// this assignment through ILT 0x00003E86 -> 0x004F68C0. The complete 537-byte
+// body ends at RET 4 (0x004F6AD6), then INT3 padding; Ghidra's 534-byte range
+// omitted that return. The string prefix ends at +0xF4. BFME's union members
+// differ from Zero Hour: the copy spans below preserve their observed sizes
+// and declaration order without assigning meanings to unrecovered payloads.
+// The largest member makes sizeof(PeerResponse) 0x330, independently confirmed
+// by the matched PeerResponse deque push/pop bodies.
+//
+// MSVC 7.1's generated assignment visits each union member. Taking its address
+// emits that real member function without adding a synthetic wrapper body.
+#include <string>
+static const int MAX_SLOTS = 8;
+class PeerResponse
+{
+public:
+	int peerResponseType;
+
+	std::string groupRoomName; // can't be in union
+
+	std::string nick;   // can't be in a union
+	std::string oldNick;   // can't be in a union
+	std::wstring text;  // can't be in a union
+	std::string locale; // can't be in a union
+
+	std::string stagingServerGameOptions; // full string from UTMs
+
+	// game opts sent with PEERRESPONSE_STAGINGROOM
+	std::wstring stagingServerName;
+	std::string stagingServerPingString;
+	std::string stagingServerLadderIP;
+	std::string stagingRoomMapName;
+
+	// game opts sent with PEERRESPONSE_STAGINGROOMPLAYERINFO
+	std::string stagingRoomPlayerNames[MAX_SLOTS];
+
+	std::string command;
+	std::string commandOptions;
+
+    union {
+        struct { int value; } payloadWord0;
+        struct { int reason; } payloadWord1;
+        struct { int words[8]; } payload32;
+        struct { int id; bool ok; } payload8a;
+        struct { int result; } payload4;
+        struct { int id; bool ok; bool isHostPresent; int result; } payload12;
+        struct { bool isPrivate; bool isAction; int profileID; } payload8b;
+        struct { int words[143]; } payload572;
+        struct { int words[53]; } payload212;
+        struct { int words[48]; } payload192;
+    };
+};
+typedef char PeerResponseSizeCheck[sizeof(PeerResponse) == 0x330 ? 1 : -1];
+
+PeerResponse & (PeerResponse::*forcePeerResponseAssignment)(const PeerResponse &) = &PeerResponse::operator=;

--- a/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerResponseCopies.cpp
+++ b/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerResponseCopies.cpp
@@ -13,8 +13,11 @@
 // by the matched PeerResponse deque push/pop bodies.
 //
 // MSVC 7.1's generated assignment visits each union member. Taking its address
-// emits that real member function without adding a synthetic wrapper body.
+// emits the assignment. The separate copy-construction emission anchor below
+// is not a claimed retail function. The matched deque push_back_aux at
+// RVA 0x00648920 names the 426-byte copy ctor through ILT0x0001E74F.
 #include <string>
+#include <new>
 static const int MAX_SLOTS = 8;
 class PeerResponse
 {
@@ -58,3 +61,9 @@ public:
 typedef char PeerResponseSizeCheck[sizeof(PeerResponse) == 0x330 ? 1 : -1];
 
 PeerResponse & (PeerResponse::*forcePeerResponseAssignment)(const PeerResponse &) = &PeerResponse::operator=;
+
+// forcePeerResponseCopy absent-from-retail: emission anchor for the implicit constructor.
+PeerResponse *forcePeerResponseCopy(PeerResponse *where, const PeerResponse &other)
+{
+    return new (where) PeerResponse(other);
+}


### PR DESCRIPTION
Recover the copy constructors and assignment operators for GameSpy `PeerRequest` and `PeerResponse` as C++, replacing three ASM claims and adding the previously unclaimed response assignment. The four complete bodies total 1,777 bytes.

| Function | RVA | Bytes |
| --- | --- | ---: |
| `PeerRequest` copy constructor | `0x00647470` | 370 |
| `PeerRequest::operator=` | `0x00648C00` | 444 |
| `PeerResponse` copy constructor | `0x004FB2E0` | 426 |
| `PeerResponse::operator=` | `0x004F68C0` | 537 |

The local class layouts use the original STLport string/vector types and opaque views of BFME's payload unions. Compiler-generated copying reproduces the observed overlapping union copies. Matched deque insertion callers independently name both copy constructors and confirm the 0x194/0x330-byte object sizes; matched `getRequest` and `getResponse` callers name the assignment operators. Each boundary includes the final `RET 4` and ends before alignment padding. The response assignment's 537-byte extent also corrects the shorter 534-byte Ghidra boundary, which omitted the return.

Validation: all four bodies match retail with their relocations resolved; normal commit and push hooks, CSV checks, pin consistency, and post-rebase claim uniqueness/record-terminator audits pass. Eight targeted caller/default-constructor/destructor controls pass. Cross-source DIR32 consistency checks report no new inconsistencies. No shared headers, symbol pins, baselines, or generated ASM were changed.

A broader `WOLLoginMenu.cpp` control build has one existing `equal_range` REL32 mismatch (47/48 pass). Its source, ledger row, and relevant callee claims/pins are unchanged from upstream; the targeted controls and all four functions in this PR pass. This is not a full-repository gate result.
